### PR TITLE
Fixes JsonMapper failure

### DIFF
--- a/src/Parts/Message.php
+++ b/src/Parts/Message.php
@@ -53,7 +53,7 @@ class Message
     public ?string $application_id;
     public ?MessageReference $message_reference;
     public ?Bitwise $flags;
-    public ?self $referenced_message;
+    public ?Message $referenced_message;
     public ?MessageInteraction $interaction;
     public ?Channel $thread;
     /**


### PR DESCRIPTION
Netscape's JsonMapper fails to parse class properties of `self` type, trying to instantiate class `self` literally.