### PR TITLE
Move InteractionHandler to use Extensions rather than custom

### DIFF
--- a/src/Discord.php
+++ b/src/Discord.php
@@ -12,6 +12,8 @@ use Ragnarok\Fenrir\Bitwise\Bitwise;
 use Ragnarok\Fenrir\Rest\Rest;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Ragnarok\Fenrir\Exceptions\Extension\ExtensionNotFoundException;
+use Ragnarok\Fenrir\Extension\Extension;
 use Ragnarok\Fenrir\Gateway\Connection;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
@@ -25,6 +27,8 @@ class Discord
     public Rest $rest;
     public Connection $gateway;
     public InteractionHandler $interaction;
+
+    private array $extensions;
 
     public function __construct(
         private string $token,
@@ -110,5 +114,34 @@ class Discord
             'os' => PHP_OS,
             'os_family' => PHP_OS_FAMILY,
         ];
+    }
+
+    /**
+     * @template Extension
+     *
+     * @param class-string<Extension>
+     * @return Extension
+     *
+     * @throws ExtensionNotFoundException
+     */
+    public function getExtension(string $id)
+    {
+        if (!$this->hasExtension($id)) {
+            throw new ExtensionNotFoundException(sprintf('Extension %s not found', $id));
+        }
+
+        return $this->extensions[$id];
+    }
+
+    public function hasExtension(string $id): bool
+    {
+        return isset($this->extensions[$id]);
+    }
+
+    public function registerExtension(Extension $extension)
+    {
+        $extension->initialize($this);
+
+        $this->extensions[get_class($extension)] = $extension;
     }
 }

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -30,6 +30,8 @@ class Discord
         private string $token,
         private LoggerInterface $logger = new NullLogger()
     ) {
+        $this->logger->info('Fenrir initialized. Discriminators > usernames');
+
         $this->loop = Loop::get();
 
         $this->mapper = new DataMapper($this->logger);

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -26,7 +26,6 @@ class Discord
 
     public Rest $rest;
     public Connection $gateway;
-    public InteractionHandler $interaction;
 
     private array $extensions;
 
@@ -75,25 +74,6 @@ class Discord
         );
 
         $this->rest = new Rest($this->http, $this->mapper, $this->logger);
-
-        return $this;
-    }
-
-    /**
-     * @param ?string $devGuildId
-     *  When passed, reroute `$this->interaction->registerCommand` to be a Guild
-     *  command rather than Global. Useful for testing without having to change
-     *  this manually. Explicitly using `registerGlobalCommand` is not affected
-     */
-    public function withInteractionHandler(?string $devGuildId = null): static
-    {
-        $args = [$this];
-
-        if (!empty($devGuildId)) {
-            $args[] = $devGuildId;
-        }
-
-        $this->interaction = new InteractionHandler(...$args);
 
         return $this;
     }

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -124,7 +124,7 @@ class Discord
      *
      * @throws ExtensionNotFoundException
      */
-    public function getExtension(string $id)
+    public function getExtension(string $id): Extension
     {
         if (!$this->hasExtension($id)) {
             throw new ExtensionNotFoundException(sprintf('Extension %s not found', $id));
@@ -138,7 +138,7 @@ class Discord
         return isset($this->extensions[$id]);
     }
 
-    public function registerExtension(Extension $extension)
+    public function registerExtension(Extension $extension): void
     {
         $extension->initialize($this);
 

--- a/src/Exceptions/Extension/ExtensionNotFoundException.php
+++ b/src/Exceptions/Extension/ExtensionNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ragnarok\Fenrir\Exceptions\Extension;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class ExtensionNotFoundException extends Exception
+{
+}

--- a/src/Extension/Extension.php
+++ b/src/Extension/Extension.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ragnarok\Fenrir\Extension;
+
+use Ragnarok\Fenrir\Discord;
+
+interface Extension
+{
+    public function initialize(Discord $discord): void;
+}

--- a/tests/DiscordTest.php
+++ b/tests/DiscordTest.php
@@ -35,24 +35,6 @@ class DiscordTest extends MockeryTestCase
         $this->assertInstanceOf(Rest::class, $discord->rest);
     }
 
-    public function testItInitializesInteractionHandler(): void
-    {
-        $discord = new Discord('::token::');
-
-        $discord->withInteractionHandler();
-
-        $this->assertInstanceOf(InteractionHandler::class, $discord->interaction);
-    }
-
-    public function testItInitializesInteractionHandlerWithDevGuild(): void
-    {
-        $discord = new Discord('::token::');
-
-        $discord->withInteractionHandler('::dev guild id::');
-
-        $this->assertInstanceOf(InteractionHandler::class, $discord->interaction);
-    }
-
     public function testGetDebugInfo(): void
     {
         $debugInfo = Discord::getDebugInfo();

--- a/tests/DiscordTest.php
+++ b/tests/DiscordTest.php
@@ -71,7 +71,7 @@ class DiscordTest extends MockeryTestCase
         }
     }
 
-    public function testItCanInitializeExtensions()
+    public function testItCanInitializeExtensions(): void
     {
         /**
          * @var Extension|MockInterface
@@ -88,7 +88,7 @@ class DiscordTest extends MockeryTestCase
         $discord->registerExtension($extension);
     }
 
-    public function testItTellsYouWhetherExtensionsAreInstalled()
+    public function testItTellsYouWhetherExtensionsAreInstalled(): void
     {
         $extension = new class implements Extension {
             public function initialize(Discord $discord): void
@@ -105,7 +105,7 @@ class DiscordTest extends MockeryTestCase
         $this->assertTrue($discord->hasExtension(get_class($extension)));
     }
 
-    public function testItReturnsTheExtension()
+    public function testItReturnsTheExtension(): void
     {
         $extension = new class implements Extension {
             public function initialize(Discord $discord): void
@@ -120,7 +120,7 @@ class DiscordTest extends MockeryTestCase
         $this->assertEquals($extension, $discord->getExtension(get_class($extension)));
     }
 
-    public function testItYellsWhenYouTryToReturnANonRegisteredExtension()
+    public function testItYellsWhenYouTryToReturnANonRegisteredExtension(): void
     {
         $extension = new class implements Extension {
             public function initialize(Discord $discord): void

--- a/tests/DiscordTest.php
+++ b/tests/DiscordTest.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Ragnarok\Fenrir;
 
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\MockInterface;
 use Ragnarok\Fenrir\Bitwise\Bitwise;
 use Ragnarok\Fenrir\Discord;
+use Ragnarok\Fenrir\Exceptions\Extension\ExtensionNotFoundException;
 use Ragnarok\Fenrir\InteractionHandler;
 use Ragnarok\Fenrir\Rest\Rest;
-use PHPUnit\Framework\TestCase;
+use Ragnarok\Fenrir\Extension\Extension;
 use Ragnarok\Fenrir\Gateway\Connection;
 
-class DiscordTest extends TestCase
+class DiscordTest extends MockeryTestCase
 {
     public function testItInitializesGateway(): void
     {
@@ -65,5 +69,69 @@ class DiscordTest extends TestCase
         foreach ($requirements as $requirement) {
             $this->assertArrayHasKey($requirement, $debugInfo);
         }
+    }
+
+    public function testItCanInitializeExtensions()
+    {
+        /**
+         * @var Extension|MockInterface
+         */
+        $extension = Mockery::mock(Extension::class);
+
+        $discord = new Discord('TOKEN');
+
+        $extension->expects()
+            ->initialize()
+            ->with($discord)
+            ->once();
+
+        $discord->registerExtension($extension);
+    }
+
+    public function testItTellsYouWhetherExtensionsAreInstalled()
+    {
+        $extension = new class implements Extension {
+            public function initialize(Discord $discord): void
+            {
+            }
+        };
+
+        $discord = new Discord('TOKEN');
+
+        $this->assertFalse($discord->hasExtension(get_class($extension)));
+
+        $discord->registerExtension($extension);
+
+        $this->assertTrue($discord->hasExtension(get_class($extension)));
+    }
+
+    public function testItReturnsTheExtension()
+    {
+        $extension = new class implements Extension {
+            public function initialize(Discord $discord): void
+            {
+            }
+        };
+
+        $discord = new Discord('TOKEN');
+
+        $discord->registerExtension($extension);
+
+        $this->assertEquals($extension, $discord->getExtension(get_class($extension)));
+    }
+
+    public function testItYellsWhenYouTryToReturnANonRegisteredExtension()
+    {
+        $extension = new class implements Extension {
+            public function initialize(Discord $discord): void
+            {
+            }
+        };
+
+        $discord = new Discord('TOKEN');
+
+        $this->expectException(ExtensionNotFoundException::class);
+
+        $this->assertEquals($extension, $discord->getExtension(get_class($extension)));
     }
 }

--- a/tests/InteractionHandlerTest.php
+++ b/tests/InteractionHandlerTest.php
@@ -45,7 +45,8 @@ class InteractionHandlerTest extends MockeryTestCase
     {
         $discord = DiscordFake::get();
 
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $commandBuilder = CommandBuilder::new()
             ->setName('command')
@@ -69,7 +70,8 @@ class InteractionHandlerTest extends MockeryTestCase
     {
         $discord = DiscordFake::get();
 
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $commandBuilder = CommandBuilder::new()
             ->setName('command')
@@ -90,36 +92,12 @@ class InteractionHandlerTest extends MockeryTestCase
         $this->emitReady($discord->gateway->events);
     }
 
-    public function testItOnlySetsASingleListener(): void
-    {
-        $discord = DiscordFake::get();
-
-        $interactionHandler = new InteractionHandler($discord);
-
-        $commandBuilder = CommandBuilder::new()
-            ->setName('command')
-            ->setDescription('::description::');
-
-        $interactionHandler->registerGuildCommand(
-            $commandBuilder,
-            '::guild id::',
-            static fn (CommandInteraction $command) => 1
-        );
-
-        $interactionHandler->registerGuildCommand(
-            $commandBuilder,
-            '::guild id::',
-            static fn (CommandInteraction $command) => 1
-        );
-
-        $this->assertCount(1, $discord->gateway->events->listeners(Events::INTERACTION_CREATE));
-    }
-
     public function testRegisterCommandIsGlobalWithoutDevGuild(): void
     {
         $discord = DiscordFake::get();
 
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $commandBuilder = CommandBuilder::new()
             ->setName('command')
@@ -139,35 +117,12 @@ class InteractionHandlerTest extends MockeryTestCase
         $this->emitReady($discord->gateway->events);
     }
 
-    public function testRegisterCommandIsGuildWithDevGuild(): void
-    {
-        $discord = DiscordFake::get();
-
-        $interactionHandler = new InteractionHandler($discord, '::guild id::');
-
-        $commandBuilder = CommandBuilder::new()
-            ->setName('command')
-            ->setDescription('::description::');
-
-        $interactionHandler->registerCommand(
-            $commandBuilder,
-            static fn (CommandInteraction $command) => 1
-        );
-
-        $interactionHandler->registerGuildCommand(
-            $commandBuilder,
-            '::guild id::',
-            static fn (CommandInteraction $command) => 1
-        );
-
-        $this->assertCount(1, $discord->gateway->events->listeners(Events::INTERACTION_CREATE));
-    }
-
     public function testItHandlesAnInteraction(): void
     {
         $discord = DiscordFake::get();
 
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $commandBuilder = CommandBuilder::new()
             ->setName('command')
@@ -233,7 +188,8 @@ class InteractionHandlerTest extends MockeryTestCase
     {
         $discord = DiscordFake::get();
 
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $commandBuilder = CommandBuilder::new()
             ->setName('command')
@@ -276,7 +232,8 @@ class InteractionHandlerTest extends MockeryTestCase
     public function testItCanRegisterButtonInteractionHandlers(): void
     {
         $discord = DiscordFake::get();
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $button = new DangerButton('::custom id::');
 
@@ -287,8 +244,6 @@ class InteractionHandlerTest extends MockeryTestCase
                 $hasRun = true;
             }
         );
-
-        $this->assertCount(1, $discord->gateway->events->listeners(Events::INTERACTION_CREATE));
 
         $interactionCreate = DataMapperFake::get()->map([
                 'id' => '::interaction id::',
@@ -306,24 +261,11 @@ class InteractionHandlerTest extends MockeryTestCase
         $this->assertTrue($hasRun, 'Handler did not run');
     }
 
-    public function testItOnlyRegistersASingleListener(): void
-    {
-        $discord = DiscordFake::get();
-        $interactionHandler = new InteractionHandler($discord);
-
-        $button = new DangerButton('::custom id::');
-        $interactionHandler->onButtonInteraction($button, static fn (ButtonInteraction $btnInt) => null);
-
-        $otherButton = new DangerButton('::some other custom id::');
-        $interactionHandler->onButtonInteraction($otherButton, static fn (ButtonInteraction $btnInt) => null);
-
-        $this->assertCount(1, $discord->gateway->events->listeners(Events::INTERACTION_CREATE));
-    }
-
     public function testItRemovesButtonListenerIfHandlerReturnsTrue(): void
     {
         $discord = DiscordFake::get();
-        $interactionHandler = new InteractionHandler($discord);
+        $interactionHandler = new InteractionHandler();
+        $interactionHandler->initialize($discord);
 
         $button = new DangerButton('::custom id::');
 
@@ -336,8 +278,6 @@ class InteractionHandlerTest extends MockeryTestCase
                 return true;
             }
         );
-
-        $this->assertCount(1, $discord->gateway->events->listeners(Events::INTERACTION_CREATE));
 
         $interactionCreate = DataMapperFake::get()->map([
                 'id' => '::interaction id::',


### PR DESCRIPTION
New way to use interaction handler

```php
$discord = (new Discord(
    'TOKEN',
    $logger
))->withGateway(new Bitwise())->withRest();

$discord->registerExtension(
    new InteractionHandler('575395886117421083')
);

$discord->getExtension(InteractionHandler::class)->registerCommand(
    (new CommandBuilder())
        ->setName('report')
        ->setType(ApplicationCommandTypes::CHAT_INPUT)
        ->setDescription('do a thing'),
    function (CommandInteraction $firedCommand) {
        $firedCommand->createInteractionResponse(
            InteractionCallbackBuilder::new()
                ->setType(InteractionCallbackTypes::CHANNEL_MESSAGE_WITH_SOURCE)
                ->setContent('Mainypainy')
        );
    }
);

$discord->gateway->open();
```