### PR TITLE
Implement new data mapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "react/event-loop": "^1.3.0",
         "ratchet/pawl": "^0.4.1",
-        "netresearch/jsonmapper": "^4.1",
         "evenement/evenement": "^3.0.0",
         "nesbot/carbon": "^2.64",
         "discord-php/http": "v10.2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,14 @@
         "evenement/evenement": "^3.0.0",
         "nesbot/carbon": "^2.64",
         "discord-php/http": "v10.2.0",
-        "monolog/monolog": "^3.2",
-        "ramsey/uuid": "^4.7",
         "ralouphie/mimey": "^1.0",
         "spatie/regex": "^3.1",
-        "guzzlehttp/guzzle": "^7.0",
         "react/async": "^4.0.0",
         "exan/eventer": "^1.0.3",
         "exan/reactphp-retrier": "^1.0"
     },
     "require-dev": {
+        "monolog/monolog": "^3.2",
         "phpunit/phpunit": "^9.5",
         "cboden/ratchet": "^0.4.4",
         "phpmd/phpmd": "^2.13",

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -6,7 +6,6 @@ namespace Ragnarok\Fenrir;
 
 use Composer\InstalledVersions;
 use Discord\Http\DriverInterface;
-use Discord\Http\Drivers\Guzzle;
 use Discord\Http\Drivers\React;
 use Discord\Http\Http;
 use Psr\Log\LoggerInterface;

--- a/src/Gateway/Events/AutoModerationActionExecution.php
+++ b/src/Gateway/Events/AutoModerationActionExecution.php
@@ -26,9 +26,4 @@ class AutoModerationActionExecution
     public ?string $content;
     public ?string $matched_keyword;
     public ?string $matched_content;
-
-    public function setRuleTriggerTypes(int $value): void
-    {
-        $this->rule_trigger_types = AutoModerationRuleTriggerType::from($value);
-    }
 }

--- a/src/Gateway/Events/GuildCreate.php
+++ b/src/Gateway/Events/GuildCreate.php
@@ -7,7 +7,14 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 use Carbon\Carbon;
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\Channel;
 use Ragnarok\Fenrir\Parts\Guild;
+use Ragnarok\Fenrir\Parts\GuildMember;
+use Ragnarok\Fenrir\Parts\GuildScheduledEvent;
+use Ragnarok\Fenrir\Parts\Presence;
+use Ragnarok\Fenrir\Parts\StageInstance;
+use Ragnarok\Fenrir\Parts\VoiceState;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#guild-create
@@ -20,25 +27,32 @@ class GuildCreate extends Guild
     public ?bool $unavailable;
     public int $member_count;
 
-    /** @var \Ragnarok\Fenrir\Parts\VoiceState[] */
+    /** @var VoiceState[] */
+    #[ArrayMapping(VoiceState::class)]
     public array $voice_states;
 
-    /** @var \Ragnarok\Fenrir\Parts\GuildMember[] */
+    /** @var GuildMember[] */
+    #[ArrayMapping(GuildMember::class)]
     public array $members;
 
-    /** @var \Ragnarok\Fenrir\Parts\Channel[] */
+    /** @var Channel[] */
+    #[ArrayMapping(Channel::class)]
     public array $channels;
 
-    /** @var \Ragnarok\Fenrir\Parts\Channel[] */
+    /** @var Channel[] */
+    #[ArrayMapping(Channel::class)]
     public array $threads;
 
-    /** @var \Ragnarok\Fenrir\Parts\Presence[] */
+    /** @var Presence[] */
     #[RequiresIntent(Intent::GUILD_PRESENCES)]
+    #[ArrayMapping(Presence::class)]
     public array $presences;
 
-    /** @var \Ragnarok\Fenrir\Parts\StageInstance[] */
+    /** @var StageInstance[] */
+    #[ArrayMapping(StageInstance::class)]
     public array $stage_instances;
 
-    /** @var \Ragnarok\Fenrir\Parts\GuildScheduledEvent[] */
+    /** @var GuildScheduledEvent[] */
+    #[ArrayMapping(GuildScheduledEvent::class)]
     public array $guild_scheduled_events;
 }

--- a/src/Gateway/Events/GuildEmojisUpdate.php
+++ b/src/Gateway/Events/GuildEmojisUpdate.php
@@ -6,6 +6,8 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\Emoji;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update
@@ -16,7 +18,8 @@ class GuildEmojisUpdate
     public string $guild_id;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\Emoji[]
+     * @var Emoji[]
      */
+    #[ArrayMapping(Emoji::class)]
     public array $emojis;
 }

--- a/src/Gateway/Events/GuildMembersChunk.php
+++ b/src/Gateway/Events/GuildMembersChunk.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Gateway\Events;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\GuildMember;
+use Ragnarok\Fenrir\Parts\Presence;
+
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
  */
@@ -12,8 +16,9 @@ class GuildMembersChunk
     public string $guild_id;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\GuildMember[]
+     * @var GuildMember[]
      */
+    #[ArrayMapping(GuildMember::class)]
     public array $members;
 
     public int $chunk_index;
@@ -21,8 +26,9 @@ class GuildMembersChunk
     public array $not_found;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\Presence[]
+     * @var Presence[]
      */
+    #[ArrayMapping(Presence::class)]
     public array $presences;
 
     public string $nonce;

--- a/src/Gateway/Events/GuildStickersUpdate.php
+++ b/src/Gateway/Events/GuildStickersUpdate.php
@@ -6,6 +6,8 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\Sticker;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update
@@ -16,7 +18,8 @@ class GuildStickersUpdate
     public string $guild_id;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\Sticker[]
+     * @var Sticker[]
      */
+    #[ArrayMapping(Sticker::class)]
     public array $stickers;
 }

--- a/src/Gateway/Events/MessageCreate.php
+++ b/src/Gateway/Events/MessageCreate.php
@@ -6,8 +6,10 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\Intent as RequiredIntents;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 use Ragnarok\Fenrir\Parts\GuildMember;
 use Ragnarok\Fenrir\Parts\Message;
+use Ragnarok\Fenrir\Parts\User;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#message-create
@@ -18,6 +20,7 @@ class MessageCreate extends Message
     /**
      * @var \Ragnarok\Fenrir\Parts\User[]
      */
+    #[ArrayMapping(User::class)]
     public array $mentions;
     public ?string $guild_id;
     public ?GuildMember $member;

--- a/src/Gateway/Events/MessageCreate.php
+++ b/src/Gateway/Events/MessageCreate.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Gateway\Events;
 
-use Ragnarok\Fenrir\Attributes\Intent as RequiredIntents;
+use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
 use Ragnarok\Fenrir\Mapping\ArrayMapping;
 use Ragnarok\Fenrir\Parts\GuildMember;
@@ -14,11 +14,13 @@ use Ragnarok\Fenrir\Parts\User;
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#message-create
  */
-#[RequiredIntents(Intent::MESSAGE_CONTENT, Intent::GUILD_MESSAGES, Intent::DIRECT_MESSAGES)]
+#[RequiresIntent(Intent::MESSAGE_CONTENT)]
+#[RequiresIntent(Intent::GUILD_MESSAGES)]
+#[RequiresIntent(Intent::DIRECT_MESSAGES)]
 class MessageCreate extends Message
 {
     /**
-     * @var \Ragnarok\Fenrir\Parts\User[]
+     * @var User[]
      */
     #[ArrayMapping(User::class)]
     public array $mentions;

--- a/src/Gateway/Events/PresenceUpdate.php
+++ b/src/Gateway/Events/PresenceUpdate.php
@@ -6,6 +6,8 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\Activity;
 use Ragnarok\Fenrir\Parts\ClientStatus;
 use Ragnarok\Fenrir\Parts\User;
 
@@ -20,8 +22,9 @@ class PresenceUpdate
     public string $status;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\Activity[]
+     * @var Activity[]
      */
+    #[ArrayMapping(Activity::class)]
     public array $activities;
 
     public ClientStatus $clientStatus;

--- a/src/Gateway/Events/Ready.php
+++ b/src/Gateway/Events/Ready.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Gateway\Objects\Payload;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 use Ragnarok\Fenrir\Parts\Application;
+use Ragnarok\Fenrir\Parts\UnavailableGuild;
 use Ragnarok\Fenrir\Parts\User;
 
 class Ready extends Payload
@@ -13,7 +15,8 @@ class Ready extends Payload
     public int $v;
     public User $user;
 
-    /** @var \Ragnarok\Fenrir\Parts\UnavailableGuild[] */
+    /** @var UnavailableGuild[] */
+    #[ArrayMapping(UnavailableGuild::class)]
     public array $guilds;
 
     public string $session_id;

--- a/src/Gateway/Events/ThreadListSync.php
+++ b/src/Gateway/Events/ThreadListSync.php
@@ -6,6 +6,8 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\Channel;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#thread-list-sync
@@ -21,8 +23,9 @@ class ThreadListSync
     public ?array $channel_ids;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\Channel[]
+     * @var Channel[]
      */
+    #[ArrayMapping(Channel::class)]
     public array $threads;
 
     public array $members;

--- a/src/Gateway/Events/ThreadMemberUpdate.php
+++ b/src/Gateway/Events/ThreadMemberUpdate.php
@@ -6,6 +6,8 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Parts\ThreadMember;
 
 /**
  * @see https://discord.com/developers/docs/topics/gateway-events#thread-members-update
@@ -18,8 +20,9 @@ class ThreadMemberUpdate
     public int $member_count;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\ThreadMember[]
+     * @var ThreadMember[]
      */
+    #[ArrayMapping(ThreadMember::class)]
     public ?array $added_members;
 
     /**

--- a/src/Gateway/Events/ThreadUpdate.php
+++ b/src/Gateway/Events/ThreadUpdate.php
@@ -6,6 +6,7 @@ namespace Ragnarok\Fenrir\Gateway\Events;
 
 use Ragnarok\Fenrir\Attributes\RequiresIntent;
 use Ragnarok\Fenrir\Enums\Intent;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 use Ragnarok\Fenrir\Parts\Channel;
 use Ragnarok\Fenrir\Parts\ThreadMember;
 
@@ -25,10 +26,12 @@ class ThreadUpdate
     /**
      * @var Channel[]
      */
+    #[ArrayMapping(Channel::class)]
     public array $threads;
 
     /**
      * @var ThreadMember[]
      */
+    #[ArrayMapping(ThreadMember::class)]
     public array $members;
 }

--- a/src/Gateway/Objects/Payload.php
+++ b/src/Gateway/Objects/Payload.php
@@ -12,9 +12,6 @@ class Payload implements JsonSerializable
     public ?int $s;
     public int $op;
 
-    /**
-     * @var mixed|null $d
-     */
     public $d;
 
     public function jsonSerialize(): mixed

--- a/src/Mapping/ArrayMapping.php
+++ b/src/Mapping/ArrayMapping.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ragnarok\Fenrir\Mapping;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class ArrayMapping
+{
+    /**
+     * @param class-string $definition
+     */
+    public function __construct(public readonly string $definition)
+    {
+    }
+}

--- a/src/Mapping/CompletedMapping.php
+++ b/src/Mapping/CompletedMapping.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ragnarok\Fenrir\Mapping;
+
+class CompletedMapping
+{
+    /**
+     * @param mixed $result
+     * @param MappingException[] $errors
+     */
+    public function __construct(public readonly mixed $result, public readonly array $errors)
+    {
+    }
+}

--- a/src/Mapping/Mapper.php
+++ b/src/Mapping/Mapper.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ragnarok\Fenrir\Mapping;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionProperty;
+use ReflectionUnionType;
+use Throwable;
+
+class Mapper
+{
+    public function map(mixed $source, string $definition): CompletedMapping
+    {
+        if (is_object($source)) {
+            return $this->mapFromObject($source, $definition);
+        }
+
+        try {
+            $constructorArgs = is_array($source) ? $source : [$source];
+            $instance = new $definition(...$constructorArgs);
+
+            return new CompletedMapping($instance, []);
+        } catch (Throwable $e) {
+            return new CompletedMapping(null, [
+                new MappingException('Unable to instantiate property', '', $definition, $e)
+            ]);
+        }
+    }
+
+    private function mapFromObject(mixed $source, string $definition): CompletedMapping
+    {
+        $reflection = new ReflectionClass($definition);
+        $instance = new $definition();
+
+        $errors = [];
+        $data = get_object_vars($source);
+
+        foreach ($data as $key => $value) {
+            try {
+                $this->setProperty(
+                    $value,
+                    $reflection->getProperty($key),
+                    $instance,
+                    $errors
+                );
+            } catch (ReflectionException $e) {
+                $errors[] = new MappingException('Property does not exist on definition', $key, $definition, $e);
+            }
+        }
+
+        return new CompletedMapping($instance, $errors);
+    }
+
+    private function setProperty(
+        mixed $value,
+        ReflectionProperty $reflectionProperty,
+        mixed &$instance,
+        array &$errors,
+    ) {
+        $type = $reflectionProperty->getType();
+
+        /**
+         * Union types will only be used for primitive union types, thus typing of source data should match allowed
+         */
+        if ($type instanceof ReflectionUnionType || is_null($type)) {
+            try {
+                $reflectionProperty->setValue($instance, $value);
+            } catch (Throwable $e) {
+                $errors[] = new MappingException($e->getMessage(), $reflectionProperty->getName(), get_class($instance), $e);
+            }
+
+            return;
+        }
+
+        /**
+         * IntersecionType is not used
+         * e.g. TypeA&TypeB
+         */
+        if ($type instanceof ReflectionIntersectionType) {
+            $errors[] = new MappingException('Unsupported typing', $reflectionProperty->getName(), get_class($instance));
+        }
+
+        if (($type instanceof ReflectionNamedType && $type->isBuiltin())) {
+            if ($type->getName() === 'array') {
+                $attributes = $reflectionProperty->getAttributes(ArrayMapping::class);
+
+                /**
+                 * Only arrays with a custom type should use the attribute
+                 */
+                $arrayValue = count($attributes) > 0
+                    ? $this->mapArray($value, array_pop($attributes)->newInstance(), $errors)
+                    : $value;
+
+                try {
+                    $reflectionProperty->setValue($instance, $arrayValue);
+                } catch (Throwable $e) {
+                    $errors[] = new MappingException($e->getMessage(), $reflectionProperty->getName(), get_class($instance), $e);
+                }
+
+                return;
+            }
+
+            try {
+                $reflectionProperty->setValue($instance, $value);
+            } catch (Throwable $e) {
+                $errors[] = new MappingException($e->getMessage(), $reflectionProperty->getName(), get_class($instance), $e);
+            }
+
+            return;
+        }
+
+        $typeName = $type->getName();
+
+        if (enum_exists($typeName)) {
+            try {
+                $reflectionProperty->setValue($instance, $typeName::tryFrom($value));
+            } catch (Throwable $e) {
+                $errors[] = new MappingException($e->getMessage(), $reflectionProperty->getName(), get_class($instance), $e);
+            }
+
+            return;
+        }
+
+        if (class_exists($typeName)) {
+            $mappedValue = $this->map($value, $typeName);
+
+            $errors = [...$errors, ...$mappedValue->errors];
+
+            try {
+                $reflectionProperty->setValue($instance, $mappedValue->result);
+            } catch (Throwable $e) {
+                $errors[] = new MappingException($e->getMessage(), $reflectionProperty->getName(), get_class($instance), $e);
+            }
+
+            return;
+        }
+
+        $errors[] = new MappingException('Unsupported typing', $reflectionProperty->getName(), get_class($instance));
+    }
+
+    private function mapArray(array $values, ArrayMapping $arrayMapping, array &$errors)
+    {
+        $new = [];
+
+        foreach ($values as $key => $value) {
+            $completedMapping = $this->map($value, $arrayMapping->definition);
+
+            $errors = [...$errors, ...$completedMapping->errors];
+            $new[$key] = $completedMapping->result;
+        }
+
+        return $new;
+    }
+}

--- a/src/Mapping/Mapper.php
+++ b/src/Mapping/Mapper.php
@@ -87,6 +87,11 @@ class Mapper
 
         if (($type instanceof ReflectionNamedType && $type->isBuiltin())) {
             if ($type->getName() === 'array') {
+                if (!is_array($value)) {
+                    $errors[] = new MappingException('Unable to map non-array to array', $reflectionProperty->getName(), get_class($instance));
+                    return;
+                }
+
                 $attributes = $reflectionProperty->getAttributes(ArrayMapping::class);
 
                 /**

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ragnarok\Fenrir\Mapping;
+
+use RuntimeException;
+use Throwable;
+
+class MappingException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly string $propertyName,
+        public readonly string $className,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, previous: $previous);
+    }
+}

--- a/src/Parts/ActiveGuildThreads.php
+++ b/src/Parts/ActiveGuildThreads.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class ActiveGuildThreads
 {
     /**
      * @var \Ragnarok\Fenrir\Parts\Channel[]
      */
+    #[ArrayMapping(Channel::class)]
     public array $threads;
 
     /**
      * @var \Ragnarok\Fenrir\Parts\ThreadMember[]
      */
+    #[ArrayMapping(ThreadMember::class)]
     public array $members;
 }

--- a/src/Parts/ActiveGuildThreads.php
+++ b/src/Parts/ActiveGuildThreads.php
@@ -9,13 +9,13 @@ use Ragnarok\Fenrir\Mapping\ArrayMapping;
 class ActiveGuildThreads
 {
     /**
-     * @var \Ragnarok\Fenrir\Parts\Channel[]
+     * @var Channel[]
      */
     #[ArrayMapping(Channel::class)]
     public array $threads;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\ThreadMember[]
+     * @var ThreadMember[]
      */
     #[ArrayMapping(ThreadMember::class)]
     public array $members;

--- a/src/Parts/Activity.php
+++ b/src/Parts/Activity.php
@@ -7,6 +7,7 @@ namespace Ragnarok\Fenrir\Parts;
 use Carbon\Carbon;
 use Ragnarok\Fenrir\Bitwise\Bitwise;
 use Ragnarok\Fenrir\Enums\ActivityType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Activity
 {
@@ -27,6 +28,7 @@ class Activity
     /**
      * @var \Ragnarok\Fenrir\Parts\ActivityButton[]
      */
+    #[ArrayMapping(ActivityButton::class)]
     public ?array $buttons;
 
     public function setType(int $value): void

--- a/src/Parts/Activity.php
+++ b/src/Parts/Activity.php
@@ -26,7 +26,7 @@ class Activity
     public bool $instance;
     public ?Bitwise $flags;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ActivityButton[]
+     * @var ActivityButton[]
      */
     #[ArrayMapping(ActivityButton::class)]
     public ?array $buttons;

--- a/src/Parts/Activity.php
+++ b/src/Parts/Activity.php
@@ -30,9 +30,4 @@ class Activity
      */
     #[ArrayMapping(ActivityButton::class)]
     public ?array $buttons;
-
-    public function setType(int $value): void
-    {
-        $this->type = ActivityType::tryFrom($value);
-    }
 }

--- a/src/Parts/ApplicationCommand.php
+++ b/src/Parts/ApplicationCommand.php
@@ -33,9 +33,4 @@ class ApplicationCommand
     public ?bool $default_permission;
     public ?bool $nsfw;
     public string $version;
-
-    public function setType(int $value): void
-    {
-        $this->type = ApplicationCommandTypes::tryFrom($value);
-    }
 }

--- a/src/Parts/ApplicationCommand.php
+++ b/src/Parts/ApplicationCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\ApplicationCommandTypes;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class ApplicationCommand
 {
@@ -14,19 +15,18 @@ class ApplicationCommand
     public ?string $guild_id;
     public string $name;
     /**
-     * Array of string => string
-     * @var string[]
+     * @var array<string, string>
      */
     public ?array $name_localizations;
     public string $description;
     /**
-     * Array of string => string
-     * @var string[]
+     * @var array<string, string>
      */
     public ?array $description_localizations;
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandOptionStructure[]
      */
+    #[ArrayMapping(ApplicationCommandOptionStructure::class)]
     public ?array $options;
     public ?string $default_member_permissions;
     public ?bool $dm_permission;

--- a/src/Parts/ApplicationCommand.php
+++ b/src/Parts/ApplicationCommand.php
@@ -24,7 +24,7 @@ class ApplicationCommand
      */
     public ?array $description_localizations;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandOptionStructure[]
+     * @var ApplicationCommandOptionStructure[]
      */
     #[ArrayMapping(ApplicationCommandOptionStructure::class)]
     public ?array $options;

--- a/src/Parts/ApplicationCommandInteractionDataOptionStructure.php
+++ b/src/Parts/ApplicationCommandInteractionDataOptionStructure.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class ApplicationCommandInteractionDataOptionStructure
 {
@@ -14,6 +15,7 @@ class ApplicationCommandInteractionDataOptionStructure
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure[]
      */
+    #[ArrayMapping(ApplicationCommandInteractionDataOptionStructure::class)]
     public ?array $options;
     public bool $focused;
 

--- a/src/Parts/ApplicationCommandInteractionDataOptionStructure.php
+++ b/src/Parts/ApplicationCommandInteractionDataOptionStructure.php
@@ -13,7 +13,7 @@ class ApplicationCommandInteractionDataOptionStructure
     public ApplicationCommandOptionType $type;
     public string|int|float|bool|null $value;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure[]
+     * @var ApplicationCommandInteractionDataOptionStructure[]
      */
     #[ArrayMapping(ApplicationCommandInteractionDataOptionStructure::class)]
     public ?array $options;

--- a/src/Parts/ApplicationCommandInteractionDataOptionStructure.php
+++ b/src/Parts/ApplicationCommandInteractionDataOptionStructure.php
@@ -18,14 +18,4 @@ class ApplicationCommandInteractionDataOptionStructure
     #[ArrayMapping(ApplicationCommandInteractionDataOptionStructure::class)]
     public ?array $options;
     public bool $focused;
-
-    public function setValue(mixed $value): void
-    {
-        $this->value = $value;
-    }
-
-    public function setType(int $value): void
-    {
-        $this->type = ApplicationCommandOptionType::tryFrom($value);
-    }
 }

--- a/src/Parts/ApplicationCommandOptionChoice.php
+++ b/src/Parts/ApplicationCommandOptionChoice.php
@@ -13,9 +13,4 @@ class ApplicationCommandOptionChoice
      */
     public ?array $name_localizations;
     public string|int|float $value;
-
-    public function setValue(mixed $value): void
-    {
-        $this->value = $value;
-    }
 }

--- a/src/Parts/ApplicationCommandOptionStructure.php
+++ b/src/Parts/ApplicationCommandOptionStructure.php
@@ -36,8 +36,8 @@ class ApplicationCommandOptionStructure
     public ?array $options;
     /**
      * @var \Ragnarok\Fenrir\Enums\ChannelType[]
-     * @todo Enum array
      */
+    #[ArrayMapping(ChannelType::class)]
     public ?array $channel_types;
     public int|float|null $min_value;
     public int|float|null $max_value;

--- a/src/Parts/ApplicationCommandOptionStructure.php
+++ b/src/Parts/ApplicationCommandOptionStructure.php
@@ -6,6 +6,7 @@ namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\ApplicationCommandOptionType;
 use Ragnarok\Fenrir\Enums\ChannelType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class ApplicationCommandOptionStructure
 {
@@ -26,10 +27,12 @@ class ApplicationCommandOptionStructure
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandOptionChoice[]
      */
+    #[ArrayMapping(ApplicationCommandOptionChoice::class)]
     public ?array $choices;
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandOptionStructure[]
      */
+    #[ArrayMapping(ApplicationCommandOptionStructure::class)]
     public ?array $options;
     /**
      * @var \Ragnarok\Fenrir\Enums\ChannelType[]

--- a/src/Parts/ApplicationCommandOptionStructure.php
+++ b/src/Parts/ApplicationCommandOptionStructure.php
@@ -36,6 +36,7 @@ class ApplicationCommandOptionStructure
     public ?array $options;
     /**
      * @var \Ragnarok\Fenrir\Enums\ChannelType[]
+     * @todo Enum array
      */
     public ?array $channel_types;
     public int|float|null $min_value;
@@ -43,28 +44,4 @@ class ApplicationCommandOptionStructure
     public ?int $min_length;
     public ?int $max_length;
     public ?bool $autocomplete;
-
-    public function setMinValue(mixed $value): void
-    {
-        $this->min_value = $value;
-    }
-
-    public function setMaxValue(mixed $value): void
-    {
-        $this->max_value = $value;
-    }
-
-    public function setType(int $value): void
-    {
-        $this->type = ApplicationCommandOptionType::tryFrom($value);
-    }
-
-    public function setChannelTypes(array $value): void
-    {
-        $this->channel_types = [];
-
-        foreach ($value as $entry) {
-            $this->channel_types[] = ChannelType::from($entry);
-        }
-    }
 }

--- a/src/Parts/ApplicationCommandOptionStructure.php
+++ b/src/Parts/ApplicationCommandOptionStructure.php
@@ -25,17 +25,17 @@ class ApplicationCommandOptionStructure
     public ?array $description_localizations;
     public ?bool $required;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandOptionChoice[]
+     * @var ApplicationCommandOptionChoice[]
      */
     #[ArrayMapping(ApplicationCommandOptionChoice::class)]
     public ?array $choices;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandOptionStructure[]
+     * @var ApplicationCommandOptionStructure[]
      */
     #[ArrayMapping(ApplicationCommandOptionStructure::class)]
     public ?array $options;
     /**
-     * @var \Ragnarok\Fenrir\Enums\ChannelType[]
+     * @var ChannelType[]
      */
     #[ArrayMapping(ChannelType::class)]
     public ?array $channel_types;

--- a/src/Parts/ApplicationCommandPermissionObject.php
+++ b/src/Parts/ApplicationCommandPermissionObject.php
@@ -12,7 +12,7 @@ class ApplicationCommandPermissionObject
     public string $application_id;
     public string $guild_id;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandPermissionStructure[]
+     * @var ApplicationCommandPermissionStructure[]
      */
     #[ArrayMapping(ApplicationCommandPermissionStructure::class)]
     public array $permissions;

--- a/src/Parts/ApplicationCommandPermissionObject.php
+++ b/src/Parts/ApplicationCommandPermissionObject.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class ApplicationCommandPermissionObject
 {
     public string $id;
@@ -12,5 +14,6 @@ class ApplicationCommandPermissionObject
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandPermissionStructure[]
      */
+    #[ArrayMapping(ApplicationCommandPermissionStructure::class)]
     public array $permissions;
 }

--- a/src/Parts/ApplicationCommandPermissionStructure.php
+++ b/src/Parts/ApplicationCommandPermissionStructure.php
@@ -11,9 +11,4 @@ class ApplicationCommandPermissionStructure
     public string $id;
     public ApplicationCommandPermissionType $type;
     public bool $permission;
-
-    public function setType(int $value): void
-    {
-        $this->type = ApplicationCommandPermissionType::tryFrom($value);
-    }
 }

--- a/src/Parts/ApplicationCommandPermissionsObject.php
+++ b/src/Parts/ApplicationCommandPermissionsObject.php
@@ -14,7 +14,7 @@ class ApplicationCommandPermissionsObject
     public string $id;
     public string $application_id;
     public string $guild_id;
-    /** @var \Ragnarok\Fenrir\Parts\ApplicationCommandPermissions[] */
+    /** @var ApplicationCommandPermissions[] */
     #[ArrayMapping(ApplicationCommandPermissions::class)]
     public array $permissions;
 }

--- a/src/Parts/ApplicationCommandPermissionsObject.php
+++ b/src/Parts/ApplicationCommandPermissionsObject.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 /**
  * @see https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object
  */
@@ -13,5 +15,6 @@ class ApplicationCommandPermissionsObject
     public string $application_id;
     public string $guild_id;
     /** @var \Ragnarok\Fenrir\Parts\ApplicationCommandPermissions[] */
+    #[ArrayMapping(ApplicationCommandPermissions::class)]
     public array $permissions;
 }

--- a/src/Parts/AuditLog.php
+++ b/src/Parts/AuditLog.php
@@ -10,42 +10,42 @@ use Ragnarok\Fenrir\Mapping\ArrayMapping;
 class AuditLog
 {
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandPermissionObject[]
+     * @var ApplicationCommandPermissionObject[]
      */
     #[ArrayMapping(ApplicationCommandPermissionObject::class)]
     public ?array $application_commands;
     /**
-     * @var \Ragnarok\Fenrir\Parts\AuditLogEntry[]
+     * @var AuditLogEntry[]
      */
     #[ArrayMapping(AuditLogEntry::class)]
     public ?array $audit_log_entries;
     /**
-     * @var \Ragnarok\Fenrir\Parts\AutoModerationRule[]
+     * @var AutoModerationRule[]
      */
     #[ArrayMapping(AutoModerationRule::class)]
     public ?array $auto_moderation_rules;
     /**
-     * @var \Ragnarok\Fenrir\Parts\GuildScheduledEvent[]
+     * @var GuildScheduledEvent[]
      */
     #[ArrayMapping(GuildScheduledEvent::class)]
     public ?array $guild_scheduled_events;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Integration[]
+     * @var Integration[]
      */
     #[ArrayMapping(Integration::class)]
     public ?array $integrations;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Channel[]
+     * @var Channel[]
      */
     #[ArrayMapping(Channel::class)]
     public ?array $threads;
     /**
-     * @var \Ragnarok\Fenrir\Parts\User[]
+     * @var User[]
      */
     #[ArrayMapping(User::class)]
     public ?array $users;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Webhook[]
+     * @var Webhook[]
      */
     #[ArrayMapping(Webhook::class)]
     public ?array $webhooks;

--- a/src/Parts/AuditLog.php
+++ b/src/Parts/AuditLog.php
@@ -5,39 +5,48 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Attributes\Partial;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class AuditLog
 {
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandPermissionObject[]
      */
+    #[ArrayMapping(ApplicationCommandPermissionObject::class)]
     public ?array $application_commands;
     /**
      * @var \Ragnarok\Fenrir\Parts\AuditLogEntry[]
      */
+    #[ArrayMapping(AuditLogEntry::class)]
     public ?array $audit_log_entries;
     /**
      * @var \Ragnarok\Fenrir\Parts\AutoModerationRule[]
      */
+    #[ArrayMapping(AutoModerationRule::class)]
     public ?array $auto_moderation_rules;
     /**
      * @var \Ragnarok\Fenrir\Parts\GuildScheduledEvent[]
      */
+    #[ArrayMapping(GuildScheduledEvent::class)]
     public ?array $guild_scheduled_events;
     /**
      * @var \Ragnarok\Fenrir\Parts\Integration[]
      */
+    #[ArrayMapping(Integration::class)]
     public ?array $integrations;
     /**
      * @var \Ragnarok\Fenrir\Parts\Channel[]
      */
+    #[ArrayMapping(Channel::class)]
     public ?array $threads;
     /**
      * @var \Ragnarok\Fenrir\Parts\User[]
      */
+    #[ArrayMapping(User::class)]
     public ?array $users;
     /**
      * @var \Ragnarok\Fenrir\Parts\Webhook[]
      */
+    #[ArrayMapping(Webhook::class)]
     public ?array $webhooks;
 }

--- a/src/Parts/AuditLogEntry.php
+++ b/src/Parts/AuditLogEntry.php
@@ -11,7 +11,7 @@ class AuditLogEntry
 {
     public ?string $target_id;
     /**
-     * @var \Ragnarok\Fenrir\Parts\AuditLogChange[]
+     * @var AuditLogChange[]
      */
     #[ArrayMapping(AuditLogChange::class)]
     public ?array $changes;

--- a/src/Parts/AuditLogEntry.php
+++ b/src/Parts/AuditLogEntry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\AuditLogEvents;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class AuditLogEntry
 {
@@ -12,6 +13,7 @@ class AuditLogEntry
     /**
      * @var \Ragnarok\Fenrir\Parts\AuditLogChange[]
      */
+    #[ArrayMapping(AuditLogChange::class)]
     public ?array $changes;
     public ?string $user_id;
     public string $id;

--- a/src/Parts/AuditLogEntry.php
+++ b/src/Parts/AuditLogEntry.php
@@ -20,9 +20,4 @@ class AuditLogEntry
     public AuditLogEvents $action_type;
     public ?OptionalAuditEntryInfo $options;
     public ?string $reason;
-
-    public function setActionType(int $value): void
-    {
-        $this->action_type = AuditLogEvents::tryFrom($value);
-    }
 }

--- a/src/Parts/AutoModerationActionStructure.php
+++ b/src/Parts/AutoModerationActionStructure.php
@@ -10,9 +10,4 @@ class AutoModerationActionStructure
 {
     public ActionType $type;
     public ?AutoModerationActionMetadata $metadata;
-
-    public function setType(int $value): void
-    {
-        $this->type = ActionType::tryFrom($value);
-    }
 }

--- a/src/Parts/AutoModerationRuleObject.php
+++ b/src/Parts/AutoModerationRuleObject.php
@@ -6,6 +6,7 @@ namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\AutoModerationRuleTriggerType;
 use Ragnarok\Fenrir\Enums\AutoModerationRuleEventType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class AutoModerationRuleObject
 {
@@ -19,6 +20,7 @@ class AutoModerationRuleObject
     /**
      * @var \Ragnarok\Fenrir\Parts\AutoModerationActionStructure[]
      */
+    #[ArrayMapping(AutoModerationActionStructure::class)]
     public array $actions;
     public bool $enabled;
     /**

--- a/src/Parts/AutoModerationRuleObject.php
+++ b/src/Parts/AutoModerationRuleObject.php
@@ -18,7 +18,7 @@ class AutoModerationRuleObject
     public AutoModerationRuleTriggerType $trigger_type;
     public AutoModerationTriggerMetadata $trigger_metadata;
     /**
-     * @var \Ragnarok\Fenrir\Parts\AutoModerationActionStructure[]
+     * @var AutoModerationActionStructure[]
      */
     #[ArrayMapping(AutoModerationActionStructure::class)]
     public array $actions;

--- a/src/Parts/AutoModerationRuleObject.php
+++ b/src/Parts/AutoModerationRuleObject.php
@@ -31,14 +31,4 @@ class AutoModerationRuleObject
      * @var string[]
      */
     public array $exempt_channels;
-
-    public function setEventType(int $value): void
-    {
-        $this->event_type = AutoModerationRuleEventType::tryFrom($value);
-    }
-
-    public function setTriggerType(int $value): void
-    {
-        $this->trigger_type = AutoModerationRuleTriggerType::tryFrom($value);
-    }
 }

--- a/src/Parts/AutoModerationTriggerMetadata.php
+++ b/src/Parts/AutoModerationTriggerMetadata.php
@@ -18,7 +18,7 @@ class AutoModerationTriggerMetadata
      */
     public array $regex_patterns;
     /**
-     * @var \Ragnarok\Fenrir\Enums\AutoModerationKeywordPresetType[]
+     * @var AutoModerationKeywordPresetType[]
      */
     #[ArrayMapping(AutoModerationKeywordPresetType::class)]
     public array $presets;

--- a/src/Parts/AutoModerationTriggerMetadata.php
+++ b/src/Parts/AutoModerationTriggerMetadata.php
@@ -19,8 +19,8 @@ class AutoModerationTriggerMetadata
     public array $regex_patterns;
     /**
      * @var \Ragnarok\Fenrir\Enums\AutoModerationKeywordPresetType[]
+     * @todo Enum array
      */
-    #[ArrayMapping(AutoModerationKeywordPresetType::class)]
     public array $presets;
     /**
      * @var string[]
@@ -28,13 +28,4 @@ class AutoModerationTriggerMetadata
     public array $allow_list;
     public int $mention_total_limit;
     public bool $mention_raid_protection_enabled;
-
-    public function setPresets(array $value): void
-    {
-        $this->presets = [];
-
-        foreach ($value as $entry) {
-            $this->presets[] = AutoModerationKeywordPresetType::from($entry);
-        }
-    }
 }

--- a/src/Parts/AutoModerationTriggerMetadata.php
+++ b/src/Parts/AutoModerationTriggerMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\AutoModerationKeywordPresetType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class AutoModerationTriggerMetadata
 {
@@ -19,6 +20,7 @@ class AutoModerationTriggerMetadata
     /**
      * @var \Ragnarok\Fenrir\Enums\AutoModerationKeywordPresetType[]
      */
+    #[ArrayMapping(AutoModerationKeywordPresetType::class)]
     public array $presets;
     /**
      * @var string[]

--- a/src/Parts/AutoModerationTriggerMetadata.php
+++ b/src/Parts/AutoModerationTriggerMetadata.php
@@ -19,8 +19,8 @@ class AutoModerationTriggerMetadata
     public array $regex_patterns;
     /**
      * @var \Ragnarok\Fenrir\Enums\AutoModerationKeywordPresetType[]
-     * @todo Enum array
      */
+    #[ArrayMapping(AutoModerationKeywordPresetType::class)]
     public array $presets;
     /**
      * @var string[]

--- a/src/Parts/Channel.php
+++ b/src/Parts/Channel.php
@@ -10,6 +10,7 @@ use Ragnarok\Fenrir\Enums\ChannelType;
 use Ragnarok\Fenrir\Enums\ForumLayoutType;
 use Ragnarok\Fenrir\Enums\SortOrderType;
 use Ragnarok\Fenrir\Enums\VideoQualityMode;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Channel
 {
@@ -20,6 +21,7 @@ class Channel
     /**
      * @var \Ragnarok\Fenrir\Parts\Overwrite[]
      */
+    #[ArrayMapping(Overwrite::class)]
     public ?array $permission_overwrites;
     public ?string $name;
     public ?string $topic;
@@ -31,6 +33,7 @@ class Channel
     /**
      * @var \Ragnarok\Fenrir\Parts\User[]
      */
+    #[ArrayMapping(User::class)]
     public ?array $recipients;
     public ?string $icon;
     public ?string $owner_id;
@@ -50,6 +53,7 @@ class Channel
     /**
      * @var \Ragnarok\Fenrir\Parts\Tag[]
      */
+    #[ArrayMapping(Tag::class)]
     public ?array $available_tags;
     /**
      * @var string[]

--- a/src/Parts/Channel.php
+++ b/src/Parts/Channel.php
@@ -63,28 +63,4 @@ class Channel
     public ?int $default_thread_rate_limit_per_user;
     public ?SortOrderType $default_sort_order;
     public ?ForumLayoutType $default_forum_layout;
-
-    public function setType(int $value): void
-    {
-        $this->type = ChannelType::tryFrom($value);
-    }
-
-    public function setVideoQualityMode(int $value): void
-    {
-        $this->video_quality_mode = VideoQualityMode::tryFrom($value);
-    }
-
-    public function setDefaultSortOrder(?int $value): void
-    {
-        if (is_null($value)) {
-            return;
-        }
-
-        $this->default_sort_order = SortOrderType::tryFrom($value);
-    }
-
-    public function setDefaultForumLayout(int $value): void
-    {
-        $this->default_forum_layout = ForumLayoutType::tryFrom($value);
-    }
 }

--- a/src/Parts/Channel.php
+++ b/src/Parts/Channel.php
@@ -19,7 +19,7 @@ class Channel
     public ?string $guild_id;
     public ?int $position;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Overwrite[]
+     * @var Overwrite[]
      */
     #[ArrayMapping(Overwrite::class)]
     public ?array $permission_overwrites;
@@ -31,7 +31,7 @@ class Channel
     public ?int $user_limit;
     public ?int $rate_limit_per_user;
     /**
-     * @var \Ragnarok\Fenrir\Parts\User[]
+     * @var User[]
      */
     #[ArrayMapping(User::class)]
     public ?array $recipients;
@@ -51,7 +51,7 @@ class Channel
     public ?Bitwise $flags;
     public ?int $total_message_sent;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Tag[]
+     * @var Tag[]
      */
     #[ArrayMapping(Tag::class)]
     public ?array $available_tags;

--- a/src/Parts/ChannelMention.php
+++ b/src/Parts/ChannelMention.php
@@ -12,9 +12,4 @@ class ChannelMention
     public string $guild_id;
     public ChannelType $type;
     public string $name;
-
-    public function setType(int $value): void
-    {
-        $this->type = ChannelType::tryFrom($value);
-    }
 }

--- a/src/Parts/Component.php
+++ b/src/Parts/Component.php
@@ -30,6 +30,7 @@ class Component
     public ?array $options; // @todo
     /**
      * @var \Ragnarok\Fenrir\Enums\ChannelType[]
+     * @todo Enum array
      */
     #[ArrayMapping(ChannelType::class)]
     public ?array $channel_types;
@@ -38,23 +39,4 @@ class Component
     public ?int $max_values;
     public ?bool $required;
     public ?string $value;
-
-    public function setChannelTypes(array $values): void
-    {
-        $this->channel_types = [];
-
-        foreach ($values as $entry) {
-            $this->channel_types[] = ChannelType::from($entry);
-        }
-    }
-
-    public function setType(int $value): void
-    {
-        $this->type = MessageComponentType::tryFrom($value);
-    }
-
-    public function setStyle(int $value): void
-    {
-        $this->style = ButtonStyle::tryFrom($value);
-    }
 }

--- a/src/Parts/Component.php
+++ b/src/Parts/Component.php
@@ -7,6 +7,7 @@ namespace Ragnarok\Fenrir\Parts;
 use Ragnarok\Fenrir\Enums\ButtonStyle;
 use Ragnarok\Fenrir\Enums\ChannelType;
 use Ragnarok\Fenrir\Enums\MessageComponentType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Component
 {
@@ -14,6 +15,7 @@ class Component
     /**
      * @var \Ragnarok\Fenrir\Parts\Component[]
      */
+    #[ArrayMapping(Component::class)]
     public ?array $components;
     public ?ButtonStyle $style;
     public ?string $label;
@@ -24,10 +26,12 @@ class Component
     /**
      * @var \Ragnarok\Fenrir\Parts\ComponentSelectOptions[]
      */
+    #[ArrayMapping(ComponentSelectOptions::class)]
     public ?array $options; // @todo
     /**
      * @var \Ragnarok\Fenrir\Enums\ChannelType[]
      */
+    #[ArrayMapping(ChannelType::class)]
     public ?array $channel_types;
     public ?string $placeholder;
     public ?int $min_values;

--- a/src/Parts/Component.php
+++ b/src/Parts/Component.php
@@ -30,7 +30,6 @@ class Component
     public ?array $options; // @todo
     /**
      * @var \Ragnarok\Fenrir\Enums\ChannelType[]
-     * @todo Enum array
      */
     #[ArrayMapping(ChannelType::class)]
     public ?array $channel_types;

--- a/src/Parts/Component.php
+++ b/src/Parts/Component.php
@@ -13,7 +13,7 @@ class Component
 {
     public MessageComponentType $type;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Component[]
+     * @var Component[]
      */
     #[ArrayMapping(Component::class)]
     public ?array $components;
@@ -24,12 +24,12 @@ class Component
     public ?string $url;
     public ?bool $disabled;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ComponentSelectOptions[]
+     * @var ComponentSelectOptions[]
      */
     #[ArrayMapping(ComponentSelectOptions::class)]
     public ?array $options; // @todo
     /**
-     * @var \Ragnarok\Fenrir\Enums\ChannelType[]
+     * @var ChannelType[]
      */
     #[ArrayMapping(ChannelType::class)]
     public ?array $channel_types;

--- a/src/Parts/Embed.php
+++ b/src/Parts/Embed.php
@@ -6,6 +6,7 @@ namespace Ragnarok\Fenrir\Parts;
 
 use Carbon\Carbon;
 use Ragnarok\Fenrir\Enums\EmbedType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Embed
 {
@@ -24,6 +25,7 @@ class Embed
     /**
      * @var \Ragnarok\Fenrir\Parts\EmbedField[]
      */
+    #[ArrayMapping(EmbedField::class)]
     public ?array $fields;
 
     public function setType(string $value): void

--- a/src/Parts/Embed.php
+++ b/src/Parts/Embed.php
@@ -23,7 +23,7 @@ class Embed
     public ?EmbedProvider $provider;
     public ?EmbedAuthor $author;
     /**
-     * @var \Ragnarok\Fenrir\Parts\EmbedField[]
+     * @var EmbedField[]
      */
     #[ArrayMapping(EmbedField::class)]
     public ?array $fields;

--- a/src/Parts/Embed.php
+++ b/src/Parts/Embed.php
@@ -27,9 +27,4 @@ class Embed
      */
     #[ArrayMapping(EmbedField::class)]
     public ?array $fields;
-
-    public function setType(string $value): void
-    {
-        $this->type = EmbedType::tryFrom($value);
-    }
 }

--- a/src/Parts/Emoji.php
+++ b/src/Parts/Emoji.php
@@ -11,7 +11,7 @@ class Emoji
     public ?string $id;
     public ?string $name;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Role[]
+     * @var Role[]
      */
     #[ArrayMapping(Role::class)]
     public ?array $roles;

--- a/src/Parts/Emoji.php
+++ b/src/Parts/Emoji.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class Emoji
 {
     public ?string $id;
@@ -11,6 +13,7 @@ class Emoji
     /**
      * @var \Ragnarok\Fenrir\Parts\Role[]
      */
+    #[ArrayMapping(Role::class)]
     public ?array $roles;
     public ?User $user;
     public ?bool $require_colons;

--- a/src/Parts/Guild.php
+++ b/src/Parts/Guild.php
@@ -34,17 +34,17 @@ class Guild
     public MessageNotificationLevel $default_message_notifications;
     public ExplicitContentFilterLevel $explicit_content_filter;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Role[]
+     * @var Role[]
      */
     #[ArrayMapping(Role::class)]
     public array $roles;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Emoji[]
+     * @var Emoji[]
      */
     #[ArrayMapping(Emoji::class)]
     public array $emojis;
     /**
-     * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
+     * @var GuildFeature[]
      */
     #[ArrayMapping(GuildFeature::class)]
     public array $features;
@@ -68,7 +68,7 @@ class Guild
     public ?WelcomeScreen $welcome_screen;
     public NsfwLevel $nsfw_level;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Sticker[]
+     * @var Sticker[]
      */
     #[ArrayMapping(Sticker::class)]
     public ?array $stickers;

--- a/src/Parts/Guild.php
+++ b/src/Parts/Guild.php
@@ -45,8 +45,8 @@ class Guild
     public array $emojis;
     /**
      * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
+     * @todo Enum array
      */
-    #[ArrayMapping(GuildFeature::class)]
     public array $features;
     public MfaLevel $mfa_level;
     public ?string $application_id;
@@ -74,43 +74,4 @@ class Guild
     public ?array $stickers;
     public bool $premium_progress_bar_enabled;
     public ?string $safety_alerts_channel_id;
-
-    public function setVerificationLevel(int $value): void
-    {
-        $this->verification_level = VerificationLevel::tryFrom($value);
-    }
-
-    public function setDefaultMessageNotifications(int $value): void
-    {
-        $this->default_message_notifications = MessageNotificationLevel::tryFrom($value);
-    }
-
-    public function setExplicitContentFilter(int $value): void
-    {
-        $this->explicit_content_filter = ExplicitContentFilterLevel::tryFrom($value);
-    }
-
-    public function setFeatures(array $value): void
-    {
-        $this->features = [];
-
-        foreach ($value as $entry) {
-            $this->features[] = GuildFeature::tryFrom($entry);
-        }
-    }
-
-    public function setMfaLevel(int $value): void
-    {
-        $this->mfa_level = MfaLevel::tryFrom($value);
-    }
-
-    public function setPremiumTier(int $value): void
-    {
-        $this->premium_tier = PremiumTier::tryFrom($value);
-    }
-
-    public function setNsfwLevel(int $value): void
-    {
-        $this->nsfw_level = NsfwLevel::tryFrom($value);
-    }
 }

--- a/src/Parts/Guild.php
+++ b/src/Parts/Guild.php
@@ -12,6 +12,7 @@ use Ragnarok\Fenrir\Enums\MfaLevel;
 use Ragnarok\Fenrir\Enums\NsfwLevel;
 use Ragnarok\Fenrir\Enums\PremiumTier;
 use Ragnarok\Fenrir\Enums\VerificationLevel;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Guild
 {
@@ -35,14 +36,17 @@ class Guild
     /**
      * @var \Ragnarok\Fenrir\Parts\Role[]
      */
+    #[ArrayMapping(Role::class)]
     public array $roles;
     /**
      * @var \Ragnarok\Fenrir\Parts\Emoji[]
      */
+    #[ArrayMapping(Emoji::class)]
     public array $emojis;
     /**
      * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
      */
+    #[ArrayMapping(GuildFeature::class)]
     public array $features;
     public MfaLevel $mfa_level;
     public ?string $application_id;
@@ -66,6 +70,7 @@ class Guild
     /**
      * @var \Ragnarok\Fenrir\Parts\Sticker[]
      */
+    #[ArrayMapping(Sticker::class)]
     public ?array $stickers;
     public bool $premium_progress_bar_enabled;
     public ?string $safety_alerts_channel_id;

--- a/src/Parts/Guild.php
+++ b/src/Parts/Guild.php
@@ -45,8 +45,8 @@ class Guild
     public array $emojis;
     /**
      * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
-     * @todo Enum array
      */
+    #[ArrayMapping(GuildFeature::class)]
     public array $features;
     public MfaLevel $mfa_level;
     public ?string $application_id;

--- a/src/Parts/GuildPreview.php
+++ b/src/Parts/GuildPreview.php
@@ -16,7 +16,7 @@ class GuildPreview
     public ?string $discovery_splash;
     public array $emojis;
     /**
-     * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
+     * @var GuildFeature[]
      */
     #[ArrayMapping(GuildFeature::class)]
     public array $features;
@@ -24,7 +24,7 @@ class GuildPreview
     public ?int $approximate_presence_count;
     public ?string $description;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Sticker[]
+     * @var Sticker[]
      */
     #[ArrayMapping(Sticker::class)]
     public ?array $stickers;

--- a/src/Parts/GuildPreview.php
+++ b/src/Parts/GuildPreview.php
@@ -17,8 +17,8 @@ class GuildPreview
     public array $emojis;
     /**
      * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
-     * @todo Enum array
      */
+    #[ArrayMapping(GuildFeature::class)]
     public array $features;
     public ?int $approximate_member_count;
     public ?int $approximate_presence_count;

--- a/src/Parts/GuildPreview.php
+++ b/src/Parts/GuildPreview.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\GuildFeature;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class GuildPreview
 {
@@ -17,6 +18,7 @@ class GuildPreview
     /**
      * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
      */
+    #[ArrayMapping(GuildFeature::class)]
     public array $features;
     public ?int $approximate_member_count;
     public ?int $approximate_presence_count;
@@ -24,6 +26,7 @@ class GuildPreview
     /**
      * @var \Ragnarok\Fenrir\Parts\Sticker[]
      */
+    #[ArrayMapping(Sticker::class)]
     public ?array $stickers;
 
     public function setFeatures(array $value): void

--- a/src/Parts/GuildPreview.php
+++ b/src/Parts/GuildPreview.php
@@ -17,8 +17,8 @@ class GuildPreview
     public array $emojis;
     /**
      * @var \Ragnarok\Fenrir\Enums\GuildFeature[]
+     * @todo Enum array
      */
-    #[ArrayMapping(GuildFeature::class)]
     public array $features;
     public ?int $approximate_member_count;
     public ?int $approximate_presence_count;
@@ -28,13 +28,4 @@ class GuildPreview
      */
     #[ArrayMapping(Sticker::class)]
     public ?array $stickers;
-
-    public function setFeatures(array $value): void
-    {
-        $this->features = [];
-
-        foreach ($value as $entry) {
-            $this->features[] = GuildFeature::from($entry);
-        }
-    }
 }

--- a/src/Parts/GuildScheduledEvent.php
+++ b/src/Parts/GuildScheduledEvent.php
@@ -27,19 +27,4 @@ class GuildScheduledEvent
     public User $creator;
     public ?int $user_count;
     public ?string $image;
-
-    public function setPrivacyLevel(int $value): void
-    {
-        $this->privacy_level = GuildScheduledEventPrivacyLevel::tryFrom($value);
-    }
-
-    public function setStatus(int $value): void
-    {
-        $this->status = GuildScheduledEventStatus::tryFrom($value);
-    }
-
-    public function setEntityType(int $value): void
-    {
-        $this->entity_type = GuildScheduledEventEntityType::tryFrom($value);
-    }
 }

--- a/src/Parts/InstallParams.php
+++ b/src/Parts/InstallParams.php
@@ -10,16 +10,8 @@ class InstallParams
 {
     /**
      * @var \Ragnarok\Fenrir\Enums\Scope[]
+     * @todo Enum array
      */
     public array $scopes;
     public string $permissions;
-
-    public function setScopes(array $value): void
-    {
-        $this->scopes = [];
-
-        foreach ($value as $entry) {
-            $this->scopes[] = Scope::from($entry);
-        }
-    }
 }

--- a/src/Parts/InstallParams.php
+++ b/src/Parts/InstallParams.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Enums\Scope;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class InstallParams
 {
     /**
      * @var \Ragnarok\Fenrir\Enums\Scope[]
-     * @todo Enum array
      */
+    #[ArrayMapping(Scope::class)]
     public array $scopes;
     public string $permissions;
 }

--- a/src/Parts/InstallParams.php
+++ b/src/Parts/InstallParams.php
@@ -10,7 +10,7 @@ use Ragnarok\Fenrir\Mapping\ArrayMapping;
 class InstallParams
 {
     /**
-     * @var \Ragnarok\Fenrir\Enums\Scope[]
+     * @var Scope[]
      */
     #[ArrayMapping(Scope::class)]
     public array $scopes;

--- a/src/Parts/Integration.php
+++ b/src/Parts/Integration.php
@@ -7,6 +7,7 @@ namespace Ragnarok\Fenrir\Parts;
 use Carbon\Carbon;
 use Ragnarok\Fenrir\Enums\IntegrationExpireBehavior;
 use Ragnarok\Fenrir\Enums\Scope;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Integration
 {
@@ -27,7 +28,7 @@ class Integration
     public ?Application $application;
     /**
      * @var \Ragnarok\Fenrir\Enums\Scope[]
-     * @todo Enum array
      */
+    #[ArrayMapping(Scope::class)]
     public ?array $scopes;
 }

--- a/src/Parts/Integration.php
+++ b/src/Parts/Integration.php
@@ -27,20 +27,7 @@ class Integration
     public ?Application $application;
     /**
      * @var \Ragnarok\Fenrir\Enums\Scope[]
+     * @todo Enum array
      */
     public ?array $scopes;
-
-    public function setExpireBehavior(int $value): void
-    {
-        $this->expire_behavior = IntegrationExpireBehavior::tryFrom($value);
-    }
-
-    public function setScopes(array $value): void
-    {
-        $this->scopes = [];
-
-        foreach ($value as $entry) {
-            $this->scopes[] = Scope::from($entry);
-        }
-    }
 }

--- a/src/Parts/Integration.php
+++ b/src/Parts/Integration.php
@@ -27,7 +27,7 @@ class Integration
     public ?bool $revoked;
     public ?Application $application;
     /**
-     * @var \Ragnarok\Fenrir\Enums\Scope[]
+     * @var Scope[]
      */
     #[ArrayMapping(Scope::class)]
     public ?array $scopes;

--- a/src/Parts/Interaction.php
+++ b/src/Parts/Interaction.php
@@ -23,14 +23,5 @@ class Interaction
     public ?string $app_permissions;
     public ?string $locale;
     public string $guild_locale;
-
-    /**
-     * @partial
-     */
     public Channel $channel;
-
-    public function setType(int $value): void
-    {
-        $this->type = InteractionType::tryFrom($value);
-    }
 }

--- a/src/Parts/InteractionData.php
+++ b/src/Parts/InteractionData.php
@@ -13,7 +13,7 @@ class InteractionData
     public int $type; // @todo enum
     public ?InteractionDataResolved $resolved;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure[]
+     * @var ApplicationCommandInteractionDataOptionStructure[]
      */
     #[ArrayMapping(ApplicationCommandInteractionDataOptionStructure::class)]
     public ?array $options;
@@ -22,7 +22,7 @@ class InteractionData
     public ?string $custom_id;
     public ?int $component_type; // @todo enum
     /**
-     * @var \Ragnarok\Fenrir\Parts\ComponentSelectOptions[]
+     * @var ComponentSelectOptions[]
      */
     #[ArrayMapping(ComponentSelectOptions::class)]
     public ?array $values;

--- a/src/Parts/InteractionData.php
+++ b/src/Parts/InteractionData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class InteractionData
 {
     public string $id;
@@ -13,6 +15,7 @@ class InteractionData
     /**
      * @var \Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure[]
      */
+    #[ArrayMapping(ApplicationCommandInteractionDataOptionStructure::class)]
     public ?array $options;
     public ?string $guild_id;
     public ?string $target_id;
@@ -21,5 +24,6 @@ class InteractionData
     /**
      * @var \Ragnarok\Fenrir\Parts\ComponentSelectOptions[]
      */
+    #[ArrayMapping(ComponentSelectOptions::class)]
     public ?array $values;
 }

--- a/src/Parts/InteractionDataResolved.php
+++ b/src/Parts/InteractionDataResolved.php
@@ -11,37 +11,37 @@ class InteractionDataResolved
 {
     /**
      * Array of string => User
-     * @var \Ragnarok\Fenrir\Parts\User[]
+     * @var User[]
      */
     #[ArrayMapping(User::class)]
     public ?array $users;
     /**
      * Array of string => GuildMember
-     * @var \Ragnarok\Fenrir\Parts\GuildMember[]
+     * @var GuildMember[]
      */
     #[ArrayMapping(GuildMember::class)]
     public ?array $members;
     /**
      * Array of string => Role
-     * @var \Ragnarok\Fenrir\Parts\Role[]
+     * @var Role[]
      */
     #[ArrayMapping(Role::class)]
     public ?array $roles;
     /**
      * Array of string => Channel
-     * @var \Ragnarok\Fenrir\Parts\Channel[]
+     * @var Channel[]
      */
     #[ArrayMapping(Channel::class)]
     public ?array $channels;
     /**
      * Array of string => Message
-     * @var \Ragnarok\Fenrir\Parts\Message[]
+     * @var Message[]
      */
     #[ArrayMapping(Message::class)]
     public ?array $messages;
     /**
      * Array of string => Attachment
-     * @var \Ragnarok\Fenrir\Parts\Attachment[]
+     * @var Attachment[]
      */
     #[ArrayMapping(Attachment::class)]
     public ?array $attachments;

--- a/src/Parts/InteractionDataResolved.php
+++ b/src/Parts/InteractionDataResolved.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Attributes\Partial;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class InteractionDataResolved
 {
@@ -12,30 +13,36 @@ class InteractionDataResolved
      * Array of string => User
      * @var \Ragnarok\Fenrir\Parts\User[]
      */
+    #[ArrayMapping(User::class)]
     public ?array $users;
     /**
      * Array of string => GuildMember
      * @var \Ragnarok\Fenrir\Parts\GuildMember[]
      */
+    #[ArrayMapping(GuildMember::class)]
     public ?array $members;
     /**
      * Array of string => Role
      * @var \Ragnarok\Fenrir\Parts\Role[]
      */
+    #[ArrayMapping(Role::class)]
     public ?array $roles;
     /**
      * Array of string => Channel
      * @var \Ragnarok\Fenrir\Parts\Channel[]
      */
+    #[ArrayMapping(Channel::class)]
     public ?array $channels;
     /**
      * Array of string => Message
      * @var \Ragnarok\Fenrir\Parts\Message[]
      */
+    #[ArrayMapping(Message::class)]
     public ?array $messages;
     /**
      * Array of string => Attachment
      * @var \Ragnarok\Fenrir\Parts\Attachment[]
      */
+    #[ArrayMapping(Attachment::class)]
     public ?array $attachments;
 }

--- a/src/Parts/Invite.php
+++ b/src/Parts/Invite.php
@@ -21,9 +21,4 @@ class Invite
     public ?Carbon $expires_at;
     public ?InviteStageInstanceObject $stage_instance;
     public ?GuildScheduledEvent $guild_scheduled_event;
-
-    public function setTargetType(int $value): void
-    {
-        $this->target_type = InviteTargetType::tryFrom($value);
-    }
 }

--- a/src/Parts/Invite.php
+++ b/src/Parts/Invite.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Carbon\Carbon;
-use Ragnarok\Fenrir\Attributes\Partial;
 use Ragnarok\Fenrir\Enums\InviteTargetType;
 
 class Invite

--- a/src/Parts/InviteStageInstanceObject.php
+++ b/src/Parts/InviteStageInstanceObject.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Ragnarok\Fenrir\Parts;
 
 use Ragnarok\Fenrir\Attributes\Partial;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class InviteStageInstanceObject
 {
     /**
      * @var \Ragnarok\Fenrir\Parts\GuildMember[]
      */
+    #[ArrayMapping(GuildMember::class)]
     public array $members;
     public int $participant_count;
     public int $speaker_count;

--- a/src/Parts/InviteStageInstanceObject.php
+++ b/src/Parts/InviteStageInstanceObject.php
@@ -10,7 +10,7 @@ use Ragnarok\Fenrir\Mapping\ArrayMapping;
 class InviteStageInstanceObject
 {
     /**
-     * @var \Ragnarok\Fenrir\Parts\GuildMember[]
+     * @var GuildMember[]
      */
     #[ArrayMapping(GuildMember::class)]
     public array $members;

--- a/src/Parts/Message.php
+++ b/src/Parts/Message.php
@@ -21,7 +21,7 @@ class Message
     public bool $tts;
     public bool $mention_everyone;
     /**
-     * @var \Ragnarok\Fenrir\Parts\User[]
+     * @var User[]
      */
     public array $mentions;
     /**
@@ -29,22 +29,22 @@ class Message
      */
     public array $mention_roles;
     /**
-     * @var \Ragnarok\Fenrir\Parts\ChannelMention[]
+     * @var ChannelMention[]
      */
     #[ArrayMapping(ChannelMention::class)]
     public ?array $mention_channels;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Attachment[]
+     * @var Attachment[]
      */
     #[ArrayMapping(Attachment::class)]
     public array $attachments;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Embed[]
+     * @var Embed[]
      */
     #[ArrayMapping(Embed::class)]
     public array $embeds;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Reaction[]
+     * @var Reaction[]
      */
     #[ArrayMapping(Reaction::class)]
     public ?array $reactions;
@@ -61,17 +61,17 @@ class Message
     public ?MessageInteraction $interaction;
     public ?Channel $thread;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Component[]
+     * @var Component[]
      */
     #[ArrayMapping(Component::class)]
     public array $components;
     /**
-     * @var \Ragnarok\Fenrir\Parts\MessageStickerItem[]
+     * @var MessageStickerItem[]
      */
     #[ArrayMapping(MessageStickerItem::class)]
     public ?array $sticker_items;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Sticker[]
+     * @var Sticker[]
      */
     #[ArrayMapping(Sticker::class)]
     public ?array $stickers;

--- a/src/Parts/Message.php
+++ b/src/Parts/Message.php
@@ -77,9 +77,4 @@ class Message
     public ?array $stickers;
     public ?int $position;
     public ?RoleSubscriptionData $role_subscription_data;
-
-    public function setType(int $value): void
-    {
-        $this->type = MessageType::tryFrom($value);
-    }
 }

--- a/src/Parts/Message.php
+++ b/src/Parts/Message.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Ragnarok\Fenrir\Attributes\Partial;
 use Ragnarok\Fenrir\Bitwise\Bitwise;
 use Ragnarok\Fenrir\Enums\MessageType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
 
 class Message
 {
@@ -30,18 +31,22 @@ class Message
     /**
      * @var \Ragnarok\Fenrir\Parts\ChannelMention[]
      */
+    #[ArrayMapping(ChannelMention::class)]
     public ?array $mention_channels;
     /**
      * @var \Ragnarok\Fenrir\Parts\Attachment[]
      */
+    #[ArrayMapping(Attachment::class)]
     public array $attachments;
     /**
      * @var \Ragnarok\Fenrir\Parts\Embed[]
      */
+    #[ArrayMapping(Embed::class)]
     public array $embeds;
     /**
      * @var \Ragnarok\Fenrir\Parts\Reaction[]
      */
+    #[ArrayMapping(Reaction::class)]
     public ?array $reactions;
     public ?string $nonce;
     public bool $pinned;
@@ -58,14 +63,17 @@ class Message
     /**
      * @var \Ragnarok\Fenrir\Parts\Component[]
      */
+    #[ArrayMapping(Component::class)]
     public array $components;
     /**
      * @var \Ragnarok\Fenrir\Parts\MessageStickerItem[]
      */
+    #[ArrayMapping(MessageStickerItem::class)]
     public ?array $sticker_items;
     /**
      * @var \Ragnarok\Fenrir\Parts\Sticker[]
      */
+    #[ArrayMapping(Sticker::class)]
     public ?array $stickers;
     public ?int $position;
     public ?RoleSubscriptionData $role_subscription_data;

--- a/src/Parts/MessageActivity.php
+++ b/src/Parts/MessageActivity.php
@@ -10,9 +10,4 @@ class MessageActivity
 {
     public MessageActivityType $type;
     public ?string $party_id;
-
-    public function setType(int $value): void
-    {
-        $this->type = MessageActivityType::tryFrom($value);
-    }
 }

--- a/src/Parts/MessageInteraction.php
+++ b/src/Parts/MessageInteraction.php
@@ -14,9 +14,4 @@ class MessageInteraction
     public string $name;
     public User $user;
     public ?GuildMember $member;
-
-    public function setType(int $value): void
-    {
-        $this->type = InteractionType::tryFrom($value);
-    }
 }

--- a/src/Parts/MessageStickerItem.php
+++ b/src/Parts/MessageStickerItem.php
@@ -11,9 +11,4 @@ class MessageStickerItem
     public string $id;
     public string $name;
     public StickerFormatType $format_type;
-
-    public function setFormatType(int $value): void
-    {
-        $this->format_type = StickerFormatType::tryFrom($value);
-    }
 }

--- a/src/Parts/Overwrite.php
+++ b/src/Parts/Overwrite.php
@@ -12,9 +12,4 @@ class Overwrite
     public OverwriteType $type;
     public string $allow;
     public string $deny;
-
-    public function setType(int $value): void
-    {
-        $this->type = OverwriteType::tryFrom($value);
-    }
 }

--- a/src/Parts/Presence.php
+++ b/src/Parts/Presence.php
@@ -12,7 +12,7 @@ class Presence
     public string $guild_id;
     public string $status;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Activity[]
+     * @var Activity[]
      */
     #[ArrayMapping(Activity::class)]
     public ?array $activities;

--- a/src/Parts/Presence.php
+++ b/src/Parts/Presence.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class Presence
 {
     public User $user;
@@ -12,6 +14,7 @@ class Presence
     /**
      * @var \Ragnarok\Fenrir\Parts\Activity[]
      */
+    #[ArrayMapping(Activity::class)]
     public ?array $activities;
     public ClientStatus $client_status;
 }

--- a/src/Parts/StageInstance.php
+++ b/src/Parts/StageInstance.php
@@ -15,9 +15,4 @@ class StageInstance
     public PrivacyLevel $privacy_level;
     public bool $discoverable_disabled;
     public ?string $guild_scheduled_event_id;
-
-    public function setPrivacyLevel(int $value): void
-    {
-        $this->privacy_level = PrivacyLevel::tryFrom($value);
-    }
 }

--- a/src/Parts/Sticker.php
+++ b/src/Parts/Sticker.php
@@ -21,14 +21,4 @@ class Sticker
     public ?string $guild_id;
     public ?User $user;
     public ?int $sort_value;
-
-    public function setType(int $value): void
-    {
-        $this->type = StickerType::tryFrom($value);
-    }
-
-    public function setFormatType(int $value): void
-    {
-        $this->format_type = StickerFormatType::tryFrom($value);
-    }
 }

--- a/src/Parts/StickerPack.php
+++ b/src/Parts/StickerPack.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class StickerPack
 {
     public string $id;
     /**
      * @var \Ragnarok\Fenrir\Parts\Sticker[]
      */
+    #[ArrayMapping(Sticker::class)]
     public array $stickers;
     public string $name;
     public string $sku_id;

--- a/src/Parts/StickerPack.php
+++ b/src/Parts/StickerPack.php
@@ -10,7 +10,7 @@ class StickerPack
 {
     public string $id;
     /**
-     * @var \Ragnarok\Fenrir\Parts\Sticker[]
+     * @var Sticker[]
      */
     #[ArrayMapping(Sticker::class)]
     public array $stickers;

--- a/src/Parts/Team.php
+++ b/src/Parts/Team.php
@@ -11,7 +11,7 @@ class Team
     public ?string $icon;
     public string $id;
     /**
-     * @var \Ragnarok\Fenrir\Parts\TeamMember[]
+     * @var TeamMember[]
      */
     #[ArrayMapping(TeamMember::class)]
     public array $members;

--- a/src/Parts/Team.php
+++ b/src/Parts/Team.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class Team
 {
     public ?string $icon;
@@ -11,6 +13,7 @@ class Team
     /**
      * @var \Ragnarok\Fenrir\Parts\TeamMember[]
      */
+    #[ArrayMapping(TeamMember::class)]
     public array $members;
     public string $name;
     public string $owner_user_id;

--- a/src/Parts/TeamMember.php
+++ b/src/Parts/TeamMember.php
@@ -15,9 +15,4 @@ class TeamMember
     public array $permissions;
     public string $team_id;
     public User $user;
-
-    public function setMembershipState(int $value): void
-    {
-        $this->membership_state = MembershipState::tryFrom($value);
-    }
 }

--- a/src/Parts/User.php
+++ b/src/Parts/User.php
@@ -27,9 +27,4 @@ class User
     public ?PremiumTier $premium_type;
     public ?Bitwise $public_flags;
     public ?GuildMember $member;
-
-    public function setPremiumType(int $value): void
-    {
-        $this->premium_type = PremiumTier::tryFrom($value);
-    }
 }

--- a/src/Parts/Webhook.php
+++ b/src/Parts/Webhook.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
-use Ragnarok\Fenrir\Attributes\Partial;
-
 class Webhook
 {
     public string $id;

--- a/src/Parts/WelcomeScreen.php
+++ b/src/Parts/WelcomeScreen.php
@@ -10,7 +10,7 @@ class WelcomeScreen
 {
     public ?string $description;
     /**
-     * @var \Ragnarok\Fenrir\Parts\WelcomeScreenChannel[]
+     * @var WelcomeScreenChannel[]
      */
     #[ArrayMapping(WelcomeScreenChannel::class)]
     public array $welcome_channels;

--- a/src/Parts/WelcomeScreen.php
+++ b/src/Parts/WelcomeScreen.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class WelcomeScreen
 {
     public ?string $description;
     /**
      * @var \Ragnarok\Fenrir\Parts\WelcomeScreenChannel[]
      */
+    #[ArrayMapping(WelcomeScreenChannel::class)]
     public array $welcome_channels;
 }

--- a/src/Parts/Widget.php
+++ b/src/Parts/Widget.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ragnarok\Fenrir\Parts;
 
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+
 class Widget
 {
     public string $id;
@@ -13,11 +15,13 @@ class Widget
     /**
      * @var \Ragnarok\Fenrir\Parts\Channel[]
      */
+    #[ArrayMapping(Channel::class)]
     public array $channels;
 
     /**
      * @var \Ragnarok\Fenrir\Parts\User[]
      */
+    #[ArrayMapping(User::class)]
     public array $users;
     public int $presence_count;
 }

--- a/src/Parts/Widget.php
+++ b/src/Parts/Widget.php
@@ -13,13 +13,13 @@ class Widget
     public ?string $instant_invite;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\Channel[]
+     * @var Channel[]
      */
     #[ArrayMapping(Channel::class)]
     public array $channels;
 
     /**
-     * @var \Ragnarok\Fenrir\Parts\User[]
+     * @var User[]
      */
     #[ArrayMapping(User::class)]
     public array $users;

--- a/tests/DataMapperTest.php
+++ b/tests/DataMapperTest.php
@@ -40,43 +40,9 @@ class DataMapperTest extends TestCase
         $this->assertEquals('::channel id::', $output->channel_id);
     }
 
-    public function testItMapsDataFromArray(): void
+    public function testItDoesNotFailHardOnImpossibleJuggles(): void
     {
-        $data = [
-            'id' => '::id::',
-            'channel_id' => '::channel id::',
-            'tts' => true,
-            'position' => 20,
-        ];
-
-        /** @var Message */
-        $output = $this->getDataMapper()->map($data, Message::class);
-
-        $this->assertInstanceOf(Message::class, $output);
-        $this->assertEquals('::id::', $output->id);
-        $this->assertEquals('::channel id::', $output->channel_id);
-    }
-
-    public function testItJugglesDataTypes(): void
-    {
-        $data = [
-            'id' => 123,
-            'tts' => 0,
-            'pinned' => 1,
-        ];
-
-        /** @var Message */
-        $output = $this->getDataMapper()->map($data, Message::class);
-
-        $this->assertInstanceOf(Message::class, $output);
-        $this->assertEquals('123', $output->id);
-        $this->assertTrue($output->pinned);
-        $this->assertFalse($output->tts);
-    }
-
-    public function testItDoesNotFailOnImpossibleJuggles(): void
-    {
-        $data = [
+        $data = (object) [
             'reactions' => 'this is supposed to be an array',
             'position' => 'ten'
         ];
@@ -91,9 +57,9 @@ class DataMapperTest extends TestCase
 
     public function testItMapsRecursively(): void
     {
-        $data = [
+        $data = (object) [
             'id' => '::interaction id::',
-            'data' => [
+            'data' => (object) [
                 'id' => '::interaction data id::',
             ],
         ];
@@ -110,19 +76,19 @@ class DataMapperTest extends TestCase
 
     public function testItMapsArrays(): void
     {
-        $data = [
+        $data = (object) [
             'id' => '::interaction id::',
             'token' => '::token::',
             'application_id' => '::application id::',
-            'data' => [
+            'data' => (object) [
                 'options' => [
-                    [
+                    (object) [
                         'name' => '::option name:: 0',
                     ],
-                    [
+                    (object) [
                         'name' => '::option name:: 1',
                     ],
-                    [
+                    (object) [
                         'name' => '::option name:: 2',
                     ]
                 ],
@@ -141,19 +107,5 @@ class DataMapperTest extends TestCase
             $this->assertInstanceOf(ApplicationCommandInteractionDataOptionStructure::class, $value);
             $this->assertEquals('::option name:: ' . $key, $value->name);
         }
-    }
-
-    public function testItUsesSettersWhenAvailable(): void
-    {
-        $data = [
-            'type' => ApplicationCommandOptionType::INTEGER->value
-        ];
-
-        /** @var ApplicationCommandInteractionDataOptionStructure */
-        $output = $this->getDataMapper()->map($data, ApplicationCommandInteractionDataOptionStructure::class);
-
-        $this->assertInstanceOf(ApplicationCommandInteractionDataOptionStructure::class, $output);
-        $this->assertInstanceOf(ApplicationCommandOptionType::class, $output->type);
-        $this->assertEquals(ApplicationCommandOptionType::INTEGER, $output->type);
     }
 }

--- a/tests/Gateway/Handlers/IdentifyHelloEventTest.php
+++ b/tests/Gateway/Handlers/IdentifyHelloEventTest.php
@@ -36,7 +36,7 @@ class IdentifyHelloEventTest extends MockeryTestCase
         $connection = Mockery::mock(ConnectionInterface::class);
         $event = new IdentifyHelloEvent(
             $connection,
-            $this->mapper->map([
+            $this->mapper->map((object) [
                 'd' => (object) [
                     'heartbeat_interval' => 123
                 ]

--- a/tests/Gateway/Handlers/IdentifyResumeEventTest.php
+++ b/tests/Gateway/Handlers/IdentifyResumeEventTest.php
@@ -36,7 +36,7 @@ class IdentifyResumeEventTest extends MockeryTestCase
         $connection = Mockery::mock(ConnectionInterface::class);
         $event = new IdentifyResumeEvent(
             $connection,
-            $this->mapper->map([
+            $this->mapper->map((object) [
                 'd' => (object) [
                     'heartbeat_interval' => 123
                 ]

--- a/tests/Gateway/Handlers/InvalidSessionEventTest.php
+++ b/tests/Gateway/Handlers/InvalidSessionEventTest.php
@@ -31,7 +31,7 @@ class InvalidSessionEventTest extends MockeryTestCase
     /**
      * @dataProvider listenerDataProvider
      */
-    public function testItListensToTheCorrectRequirements(array $payload, bool $expect): void
+    public function testItListensToTheCorrectRequirements(object $payload, bool $expect): void
     {
         $event = new InvalidSessionEvent(
             Mockery::mock(ConnectionInterface::class),
@@ -46,13 +46,13 @@ class InvalidSessionEventTest extends MockeryTestCase
     {
         return [
             'Payload D => true' => [
-                'payload' => [
+                'payload' => (object) [
                     'd' => true
                 ],
                 'expect' => false,
             ],
             'Payload D => false' => [
-                'payload' => [
+                'payload' => (object) [
                     'd' => false
                 ],
                 'expect' => true,
@@ -67,7 +67,7 @@ class InvalidSessionEventTest extends MockeryTestCase
 
         $event = new InvalidSessionEvent(
             $connection,
-            $this->mapper->map(['d' => false], Payload::class),
+            $this->mapper->map((object) ['d' => false], Payload::class),
             new NullLogger(),
         );
 
@@ -117,7 +117,7 @@ class InvalidSessionEventTest extends MockeryTestCase
 
         $event = new InvalidSessionEvent(
             $connection,
-            $this->mapper->map(['d' => false], Payload::class),
+            $this->mapper->map((object) ['d' => false], Payload::class),
             new NullLogger(),
         );
 

--- a/tests/Gateway/Handlers/PassthroughEventTest.php
+++ b/tests/Gateway/Handlers/PassthroughEventTest.php
@@ -34,7 +34,7 @@ class PassthroughEventTest extends MockeryTestCase
     {
         /** @var MockInterface&ConnectionInterface */
         $connection = Mockery::mock(ConnectionInterface::class);
-        $payload = $this->mapper->map([], Payload::class);
+        $payload = $this->mapper->map((object) [], Payload::class);
 
         $event = new PassthroughEvent(
             $connection,
@@ -65,7 +65,7 @@ class PassthroughEventTest extends MockeryTestCase
     {
         /** @var MockInterface&ConnectionInterface */
         $connection = Mockery::mock(ConnectionInterface::class);
-        $payload = $this->mapper->map(['s' => 123], Payload::class);
+        $payload = $this->mapper->map((object) ['s' => 123], Payload::class);
 
         $event = new PassthroughEvent(
             $connection,
@@ -101,7 +101,7 @@ class PassthroughEventTest extends MockeryTestCase
     {
         /** @var MockInterface&ConnectionInterface */
         $connection = Mockery::mock(ConnectionInterface::class);
-        $payload = $this->mapper->map(['s' => 123], Payload::class);
+        $payload = $this->mapper->map((object) ['s' => 123], Payload::class);
 
         $event = new PassthroughEvent(
             $connection,
@@ -138,7 +138,7 @@ class PassthroughEventTest extends MockeryTestCase
     {
         /** @var MockInterface&ConnectionInterface */
         $connection = Mockery::mock(ConnectionInterface::class);
-        $payload = $this->mapper->map(['s' => 123], Payload::class);
+        $payload = $this->mapper->map((object) ['s' => 123], Payload::class);
 
         $event = new PassthroughEvent(
             $connection,

--- a/tests/Gateway/Handlers/ReadyEventTest.php
+++ b/tests/Gateway/Handlers/ReadyEventTest.php
@@ -28,7 +28,7 @@ class ReadyEventTest extends MockeryTestCase
     /**
      * @dataProvider listenerDataProvider
      */
-    public function testItListensToTheCorrectEvent(array $payload, bool $expectation): void
+    public function testItListensToTheCorrectEvent(object $payload, bool $expectation): void
     {
         $event = new ReadyEvent(
             Mockery::mock(ConnectionInterface::class),
@@ -43,19 +43,19 @@ class ReadyEventTest extends MockeryTestCase
     {
         return [
             'Ready event' => [
-                'payload' => [
+                'payload' => (object) [
                     't' => Events::READY
                 ],
                 'expectation' => true,
             ],
             'Other event' => [
-                'payload' => [
+                'payload' => (object) [
                     't' => Events::AUTO_MODERATION_ACTION_EXECUTION
                 ],
                 'expectation' => false,
             ],
             'No type' => [
-                'payload' => [],
+                'payload' => (object) [],
                 'expectation' => false,
             ],
         ];
@@ -64,7 +64,7 @@ class ReadyEventTest extends MockeryTestCase
     /**
      * @dataProvider payloadProvider
      */
-    public function testItSetsResumeUrlAndSessionId(array $payload, bool $shouldSet): void
+    public function testItSetsResumeUrlAndSessionId(object $payload, bool $shouldSet): void
     {
         /** @var MockInterface&ConnectionInterface */
         $connection = Mockery::mock(ConnectionInterface::class);
@@ -97,7 +97,7 @@ class ReadyEventTest extends MockeryTestCase
     {
         return [
             'All filled in' => [
-                'payload' => [
+                'payload' => (object) [
                     't' => Events::READY,
                     'd' => (object) [
                         'resume_gateway_url' => '::resume gateway url::',
@@ -108,7 +108,7 @@ class ReadyEventTest extends MockeryTestCase
             ],
 
             'No resume url' => [
-                'payload' => [
+                'payload' => (object) [
                     't' => Events::READY,
                     'd' => (object) [
                         'session_id' => '::session id::',
@@ -118,7 +118,7 @@ class ReadyEventTest extends MockeryTestCase
             ],
 
             'No session id' => [
-                'payload' => [
+                'payload' => (object) [
                     't' => Events::READY,
                     'd' => (object) [
                         'resume_gateway_url' => '::resume gateway url::',
@@ -128,7 +128,7 @@ class ReadyEventTest extends MockeryTestCase
             ],
 
             'No d' => [
-                'payload' => [
+                'payload' => (object) [
                     't' => Events::READY,
                 ],
                 'expectation' => false,

--- a/tests/Gateway/Handlers/ReconnectEventTest.php
+++ b/tests/Gateway/Handlers/ReconnectEventTest.php
@@ -79,7 +79,7 @@ class ReconnectEventTest extends MockeryTestCase
 
         $event = new ReconnectEvent(
             $connection,
-            $this->mapper->map([], Payload::class),
+            $this->mapper->map((object) [], Payload::class),
             new NullLogger(),
         );
 
@@ -130,7 +130,7 @@ class ReconnectEventTest extends MockeryTestCase
 
         $event = new ReconnectEvent(
             $connection,
-            $this->mapper->map([], Payload::class),
+            $this->mapper->map((object) [], Payload::class),
             new NullLogger(),
         );
 
@@ -192,7 +192,7 @@ class ReconnectEventTest extends MockeryTestCase
 
         $event = new ReconnectEvent(
             $connection,
-            $this->mapper->map([], Payload::class),
+            $this->mapper->map((object) [], Payload::class),
             new NullLogger(),
         );
 

--- a/tests/Gateway/Handlers/RecoverableInvalidSessionEventTest.php
+++ b/tests/Gateway/Handlers/RecoverableInvalidSessionEventTest.php
@@ -38,7 +38,7 @@ class RecoverableInvalidSessionEventTest extends MockeryTestCase
     /**
      * @dataProvider listenerDataProvider
      */
-    public function testItListensToTheCorrectRequirements(array $payload, bool $expect): void
+    public function testItListensToTheCorrectRequirements(object $payload, bool $expect): void
     {
         $event = new RecoverableInvalidSessionEvent(
             Mockery::mock(ConnectionInterface::class),
@@ -53,13 +53,13 @@ class RecoverableInvalidSessionEventTest extends MockeryTestCase
     {
         return [
             'Payload D => true' => [
-                'payload' => [
+                'payload' => (object) [
                     'd' => true
                 ],
                 'expect' => true,
             ],
             'Payload D => false' => [
-                'payload' => [
+                'payload' => (object) [
                     'd' => false
                 ],
                 'expect' => false,
@@ -111,7 +111,7 @@ class RecoverableInvalidSessionEventTest extends MockeryTestCase
 
         $event = new RecoverableInvalidSessionEvent(
             $connection,
-            $this->mapper->map([], Payload::class),
+            $this->mapper->map((object) [], Payload::class),
             new NullLogger(),
         );
 
@@ -162,7 +162,7 @@ class RecoverableInvalidSessionEventTest extends MockeryTestCase
 
         $event = new RecoverableInvalidSessionEvent(
             $connection,
-            $this->mapper->map([], Payload::class),
+            $this->mapper->map((object) [], Payload::class),
             new NullLogger(),
         );
 
@@ -224,7 +224,7 @@ class RecoverableInvalidSessionEventTest extends MockeryTestCase
 
         $event = new RecoverableInvalidSessionEvent(
             $connection,
-            $this->mapper->map([], Payload::class),
+            $this->mapper->map((object) [], Payload::class),
             new NullLogger(),
         );
 

--- a/tests/Interaction/CommandInteractionTest.php
+++ b/tests/Interaction/CommandInteractionTest.php
@@ -116,13 +116,13 @@ class CommandInteractionTest extends MockeryTestCase
 
         /** @var InteractionCreate */
         $interactionCreate = $dataMapper->map(
-            [
+            (object) [
                 'id' => '::interaction id::',
                 'token' => '::token::',
                 'application_id' => '::application id::',
-                'data' => [
+                'data' => (object) [
                     'options' => [
-                        [
+                        (object) [
                             'name' => '::option name::',
                             'type' => 1,
                         ]
@@ -143,17 +143,17 @@ class CommandInteractionTest extends MockeryTestCase
 
         /** @var InteractionCreate */
         $interactionCreate = $dataMapper->map(
-            [
+            (object) [
                 'id' => '::interaction id::',
                 'token' => '::token::',
                 'application_id' => '::application id::',
-                'data' => [
+                'data' => (object) [
                     'options' => [
-                        [
+                        (object) [
                             'name' => 'group_name',
                             'type' => 2,
                             'options' => [
-                                [
+                                (object) [
                                     'name' => 'option_name',
                                     'type' => 1,
                                 ]
@@ -176,13 +176,13 @@ class CommandInteractionTest extends MockeryTestCase
 
         /** @var InteractionCreate */
         $interactionCreate = $dataMapper->map(
-            [
+            (object) [
                 'id' => '::interaction id::',
                 'token' => '::token::',
                 'application_id' => '::application id::',
-                'data' => [
+                'data' => (object) [
                     'options' => [
-                        [
+                        (object) [
                             'name' => '::option name::',
                             'type' => 3,
                         ]

--- a/tests/InteractionHandlerTest.php
+++ b/tests/InteractionHandlerTest.php
@@ -26,11 +26,11 @@ class InteractionHandlerTest extends MockeryTestCase
     private function emitReady(EventHandler $eventHandler): void
     {
         /** @var Payload */
-        $payload = DataMapperFake::get()->map([
+        $payload = DataMapperFake::get()->map((object) [
             'op' => 0,
             't' => Events::READY,
-            'd' => [
-                'user' => [
+            'd' => (object) [
+                'user' => (object) [
                     'id' => '::bot user id::',
                 ],
             ],
@@ -132,7 +132,7 @@ class InteractionHandlerTest extends MockeryTestCase
             ->shouldReceive('createApplicationCommand')
             ->with('::bot user id::', $commandBuilder)
             ->andReturn(PromiseFake::get(
-                DataMapperFake::get()->map([
+                DataMapperFake::get()->map((object) [
                     'id' => '::application command id::',
                 ], ApplicationCommand::class)
             ))
@@ -142,7 +142,7 @@ class InteractionHandlerTest extends MockeryTestCase
             ->shouldReceive('createApplicationCommand')
             ->with('::bot user id::', '::guild id::', $commandBuilder)
             ->andReturn(PromiseFake::get(
-                DataMapperFake::get()->map([
+                DataMapperFake::get()->map((object) [
                     'id' => '::guild application command id::',
                 ], ApplicationCommand::class)
             ))
@@ -172,9 +172,9 @@ class InteractionHandlerTest extends MockeryTestCase
         $this->emitReady($discord->gateway->events);
 
         /** @var InteractionCreate */
-        $interactionCreate = DataMapperFake::get()->map([
+        $interactionCreate = DataMapperFake::get()->map((object) [
             'type' => InteractionType::APPLICATION_COMMAND->value,
-            'data' => [
+            'data' => (object) [
                 'id' => '::application command id::',
             ],
         ], InteractionCreate::class);
@@ -199,7 +199,7 @@ class InteractionHandlerTest extends MockeryTestCase
             ->shouldReceive('createApplicationCommand')
             ->with('::bot user id::', $commandBuilder)
             ->andReturn(PromiseFake::get(
-                DataMapperFake::get()->map([
+                DataMapperFake::get()->map((object) [
                     'id' => '::application command id::',
                 ], ApplicationCommand::class)
             ))
@@ -217,9 +217,9 @@ class InteractionHandlerTest extends MockeryTestCase
         $this->emitReady($discord->gateway->events);
 
         /** @var InteractionCreate */
-        $interactionCreate = DataMapperFake::get()->map([
+        $interactionCreate = DataMapperFake::get()->map((object) [
             'type' => InteractionType::APPLICATION_COMMAND->value,
-            'data' => [
+            'data' => (object) [
                 'id' => '::other application command id::',
             ],
         ], InteractionCreate::class);
@@ -245,12 +245,12 @@ class InteractionHandlerTest extends MockeryTestCase
             }
         );
 
-        $interactionCreate = DataMapperFake::get()->map([
+        $interactionCreate = DataMapperFake::get()->map((object) [
                 'id' => '::interaction id::',
                 'token' => '::token::',
                 'type' => InteractionType::MESSAGE_COMPONENT->value,
                 'application_id' => '::application id::',
-                'data' => [
+                'data' => (object) [
                     'component_type' => 2, // @todo enum
                     'custom_id' => '::custom id::',
                 ],
@@ -279,12 +279,12 @@ class InteractionHandlerTest extends MockeryTestCase
             }
         );
 
-        $interactionCreate = DataMapperFake::get()->map([
+        $interactionCreate = DataMapperFake::get()->map((object) [
                 'id' => '::interaction id::',
                 'token' => '::token::',
                 'type' => InteractionType::MESSAGE_COMPONENT->value,
                 'application_id' => '::application id::',
-                'data' => [
+                'data' => (object) [
                     'component_type' => 2, // @todo enum
                     'custom_id' => '::custom id::',
                 ],

--- a/tests/Mapping/MapperTest.php
+++ b/tests/Mapping/MapperTest.php
@@ -255,4 +255,31 @@ class MapperTest extends TestCase
             })(),
         ];
     }
+
+    public function testItMapsEnumArrays()
+    {
+        $definition = new class () {
+            #[ArrayMapping(MessageType::class)]
+            public array $test;
+        };
+
+        $source = (object) [
+            'test' => [
+                0,
+                1,
+                2,
+            ],
+        ];
+
+        $result = $this->mapper->map($source, $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertEmpty($result->errors);
+
+        $this->assertEquals([
+            MessageType::DEFAULT,
+            MessageType::RECIPIENT_ADD,
+            MessageType::RECIPIENT_REMOVE,
+        ], $result->result->test);
+    }
 }

--- a/tests/Mapping/MapperTest.php
+++ b/tests/Mapping/MapperTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Ragnarok\Fenrir\Mapping;
+
+use Carbon\Carbon;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Ragnarok\Fenrir\Discord;
+use Ragnarok\Fenrir\Enums\MessageType;
+use Ragnarok\Fenrir\Mapping\ArrayMapping;
+use Ragnarok\Fenrir\Mapping\Mapper;
+use Ragnarok\Fenrir\Parts\EmbedField;
+
+class MapperTest extends TestCase
+{
+    private Mapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new Mapper();
+    }
+
+    public function testItMapsIntoObjectsUsingConstructor(): void
+    {
+        $datetime = Carbon::now();
+        $source = $datetime->toIso8601String();
+
+        $result = $this->mapper->map($source, Carbon::class);
+
+        $this->assertInstanceOf(Carbon::class, $result->result);
+        $this->assertEquals($source, $result->result->toIso8601String());
+        $this->assertEmpty($result->errors);
+    }
+
+    public function testItCreatesAnObjectAndSetsScalarProperties(): void
+    {
+        $definition = new class () {
+            public bool $boolTest;
+            public int $intTest;
+            public float $floatTest;
+            public string $stringTest;
+            public array $arrayTest;
+        };
+
+        $result = $this->mapper->map((object) [
+            'boolTest' => true,
+            'intTest' => 123,
+            'floatTest' => 123.456,
+            'stringTest' => 'Hello',
+            'arrayTest' => ['Hello', 'world'],
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertEquals(true, $result->result->boolTest);
+        $this->assertEquals(123, $result->result->intTest);
+        $this->assertEquals(123.456, $result->result->floatTest);
+        $this->assertEquals('Hello', $result->result->stringTest);
+        $this->assertEquals(['Hello', 'world'], $result->result->arrayTest);
+        $this->assertEmpty($result->errors);
+    }
+
+    public function testItNonTypedProperties(): void
+    {
+        $definition = new class () {
+            public $test;
+        };
+
+        $result = $this->mapper->map((object) [
+            'test' => 'Hello',
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertEquals('Hello', $result->result->test);
+        $this->assertEmpty($result->errors);
+
+        $result = $this->mapper->map((object) [
+            'test' => true,
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertTrue($result->result->test);
+        $this->assertEmpty($result->errors);
+    }
+
+    public function testItSetsUnionTypes(): void
+    {
+        $definition = new class () {
+            public string|bool $test;
+        };
+
+        $result = $this->mapper->map((object) [
+            'test' => 'Hello',
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertEquals('Hello', $result->result->test);
+        $this->assertEmpty($result->errors);
+
+        $result = $this->mapper->map((object) [
+            'test' => true,
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertTrue($result->result->test);
+        $this->assertEmpty($result->errors);
+    }
+
+    public function testItDoesNotSupportIntersectionTypes(): void
+    {
+        $definition = new class () {
+            public Carbon&MockInterface $test;
+        };
+
+        $result = $this->mapper->map((object) [
+            'test' => 'Hello',
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertFalse(isset($result->result->test));
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function testItDoesNotAllowNonArraysToArrayMapping(): void
+    {
+        $definition = new class () {
+            public array $test;
+        };
+
+        $result = $this->mapper->map((object) [
+            'test' => 'Hello',
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertFalse(isset($result->result->test));
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public function testItAllowsTypedArrays()
+    {
+        $definition = new class () {
+            #[ArrayMapping(EmbedField::class)]
+            public array $test;
+        };
+
+        $source = (object) [
+            'test' => [
+                (object) [
+                    'name' => '::name::',
+                    'value' => '::value::',
+                    'inline' => false,
+                ],
+            ],
+        ];
+
+        $result = $this->mapper->map($source, $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertEmpty($result->errors);
+
+        $this->assertInstanceOf(EmbedField::class, $result->result->test[0]);
+        $this->assertEquals('::name::', $result->result->test[0]->name);
+        $this->assertEquals('::value::', $result->result->test[0]->value);
+        $this->assertFalse($result->result->test[0]->inline);
+    }
+
+    public function testItSetsEnums(): void
+    {
+        $definition = new class () {
+            public MessageType $test;
+        };
+
+        $result = $this->mapper->map((object) [
+            'test' => 0,
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertEquals(MessageType::DEFAULT, $result->result->test);
+        $this->assertEmpty($result->errors);
+    }
+
+    public function testItSetsClassTypedProperties(): void
+    {
+        $definition = new class () {
+            public EmbedField $test;
+        };
+
+        $result = $this->mapper->map((object) [
+            'test' => (object) [
+                'name' => '::name::',
+                'value' => '::value::',
+                'inline' => false,
+            ],
+        ], $definition::class);
+
+        $this->assertInstanceOf($definition::class, $result->result);
+        $this->assertInstanceOf(EmbedField::class, $result->result->test);
+        $this->assertEquals('::name::', $result->result->test->name);
+        $this->assertEquals('::value::', $result->result->test->value);
+        $this->assertFalse($result->result->test->inline);
+        $this->assertEmpty($result->errors);
+    }
+
+    /**
+     * @dataProvider incorrectAssignmentsProvider
+     */
+    public function testItReturnsErrorsForIncorrectAssignments(string $definition, $source)
+    {
+        $result = $this->mapper->map($source, $definition);
+
+        $this->assertNotEmpty($result->errors);
+    }
+
+    public static function incorrectAssignmentsProvider()
+    {
+        return [
+            'Non existing enum case, resulting on null on non-nullable prop' => (function () {
+                $definition = new class () {
+                    public MessageType $test;
+                };
+
+                return [
+                    'definition' => $definition::class,
+                    'source' => (object) [
+                        'test' => 9001,
+                    ],
+                ];
+            })(),
+
+            'Instantiating class with wrong args' => (function () {
+                $definition = new class ([]) {
+                    public function __construct(array $test)
+                    {
+                    }
+                };
+
+                return [
+                    'definition' => $definition::class,
+                    'source' => 'hello world',
+                ];
+            })(),
+
+            'Instantiating class with wrong args as property, resulting in null on non-nullable prop' => (function () {
+                $definition = new class () {
+                    public Discord $test;
+                };
+
+                return [
+                    'definition' => $definition::class,
+                    'source' => (object) [
+                        'test' => [['hi there']]
+                    ],
+                ];
+            })(),
+        ];
+    }
+}


### PR DESCRIPTION
Implement new custom datamapper

Old mapper constantly caused issues since it couldn't fail silently over properties. If a single property is misaligned, the whole mapping will fail.

New mapper will continue on if a single property fails to map, and logs issues it had.

Some definitions will still be broken and require updating, but at least they won't be as breaking as the previous mapper.


None of the already existing json mappers / data normalizers seemed to be able to map properties without a hard fail, thus had to go custom.

Pre-merge checklist:
- [x] Presence update is merged & released as 0.9.X