### PR TITLE
Improved option search with iterative approach

### DIFF
--- a/src/Interaction/CommandInteraction.php
+++ b/src/Interaction/CommandInteraction.php
@@ -86,9 +86,10 @@ class CommandInteraction
         return null;
     }
 
-    public function hasOption($option): bool
+    public function hasOption(string $path): bool
     {
-        return isset($this->options[$option]);
+        $segments = explode('.', $path);
+        return $this->findOption($this->options, $segments) !== null;
     }
 
     public function getSubCommandName(): ?string

--- a/src/Interaction/CommandInteraction.php
+++ b/src/Interaction/CommandInteraction.php
@@ -12,6 +12,8 @@ use Ragnarok\Fenrir\Parts\ApplicationCommandInteractionDataOptionStructure as Op
 use Ragnarok\Fenrir\Rest\Helpers\Webhook\EditWebhookBuilder;
 use React\Promise\ExtendedPromiseInterface;
 
+use function Freezemage\ArrayUtils\find as array_find;
+
 class CommandInteraction
 {
     /** @var OptionStructure[] */
@@ -71,19 +73,13 @@ class CommandInteraction
     {
         $currentSegment = array_shift($segments);
 
-        foreach ($options as $opt) {
-            if ($opt->name === $currentSegment) {
-                if (empty($segments)) {
-                    return $opt;
-                }
+        $option = array_find($options, fn (OptionStructure $option) => $option->name === $currentSegment);
 
-                if (!empty($opt->options)) {
-                    return $this->findOption($opt->options, $segments);
-                }
-            }
+        if (empty($segments)) {
+            return $option;
         }
 
-        return null;
+        return empty($option->options) ? null : $this->findOption($option->options, $segments);
     }
 
     public function hasOption(string $path): bool

--- a/src/Interaction/CommandInteraction.php
+++ b/src/Interaction/CommandInteraction.php
@@ -61,9 +61,29 @@ class CommandInteraction
         );
     }
 
-    public function getOption($option): ?OptionStructure
+    public function getOption(string $path): ?OptionStructure
     {
-        return $this->options[$option] ?? null;
+        $segments = explode('.', $path);
+        return $this->findOption($this->options, $segments);
+    }
+
+    private function findOption(array $options, array $segments): ?OptionStructure
+    {
+        $currentSegment = array_shift($segments);
+
+        foreach ($options as $opt) {
+            if ($opt->name === $currentSegment) {
+                if (empty($segments)) {
+                    return $opt;
+                }
+
+                if (!empty($opt->options)) {
+                    return $this->findOption($opt->options, $segments);
+                }
+            }
+        }
+
+        return null;
     }
 
     public function hasOption($option): bool

--- a/tests/Interaction/CommandInteractionTest.php
+++ b/tests/Interaction/CommandInteractionTest.php
@@ -108,6 +108,29 @@ class CommandInteractionTest extends MockeryTestCase
 
         $this->assertNull($commandInteraction->getOption('other_name'));
         $this->assertEquals($interactionCreate->data->options[0], $commandInteraction->getOption('funny_name'));
+
+        $interactionCreate = $this->getInteractionCreate();
+
+        $interactionCreate->data = new InteractionData();
+        $interactionCreate->data->options = [
+            new ApplicationCommandInteractionDataOptionStructure()
+        ];
+
+        $interactionCreate->data->options[0]->name = 'foo';
+        $interactionCreate->data->options[0]->type = \Ragnarok\Fenrir\Enums\ApplicationCommandOptionType::SUB_COMMAND;
+        $interactionCreate->data->options[0]->options = [
+            new ApplicationCommandInteractionDataOptionStructure()
+        ];
+        $interactionCreate->data->options[0]->options[0]->name = 'bar';
+        $interactionCreate->data->options[0]->options[0]->value = '::value::';
+
+        $commandInteraction = new CommandInteraction($interactionCreate, DiscordFake::get());
+
+        $this->assertTrue($commandInteraction->hasOption('foo.bar'));
+        $this->assertFalse($commandInteraction->hasOption('foo.baz'));
+
+        $this->assertNull($commandInteraction->getOption('foo.baz'));
+        $this->assertEquals($interactionCreate->data->options[0]->options[0], $commandInteraction->getOption('foo.bar'));
     }
 
     public function testGetSubCommandName(): void


### PR DESCRIPTION
This pull request improves the getOption method by allowing it to search for nested options using a dot-separated path, like $option = $command->getOption('foo.bar'). This new approach replaces the previous method and provides better support for nested structures, especially for options of type ApplicationCommandOptionType::SUB_COMMAND. The old method does not support nested structures and will fail if you try to retrieve bar from foo.bar.