### PR TITLE
Reconnect instead of resume on unacknowledged heartbeat

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Install PHP 8.1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -22,7 +22,7 @@ jobs:
       run: bash util/verify-namespacing.sh
 
   phpmd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Install PHP 8.1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/src/Gateway/Connection.php
+++ b/src/Gateway/Connection.php
@@ -112,7 +112,7 @@ class Connection implements ConnectionInterface
         $description = GatewayCloseCodes::DESCRIPTIONS[$code] ?? sprintf('Unknown error code %d - %s', $code, $reason);
         $isUserError = GatewayCloseCodes::USER_ERROR[$code] ?? false;
         $isRecoverable = GatewayCloseCodes::RECOVERABLE[$code] ?? false;
-        $isResumable = GatewayCloseCodes::RECOVERABLE[$code] ?? false;
+        $isResumable = GatewayCloseCodes::RESUMABLE[$code] ?? false;
 
         $message = $description . ' '
             . (

--- a/src/Gateway/Handlers/InvalidSessionEvent.php
+++ b/src/Gateway/Handlers/InvalidSessionEvent.php
@@ -6,7 +6,6 @@ namespace Ragnarok\Fenrir\Gateway\Handlers;
 
 use Ragnarok\Fenrir\Constants\GatewayCloseCodes;
 use Ragnarok\Fenrir\Constants\OpCodes;
-use Ragnarok\Fenrir\Gateway\Objects\Payload;
 
 class InvalidSessionEvent extends GatewayEvent
 {

--- a/src/Gateway/Handlers/Meta/UnacknowledgedHeartbeatEvent.php
+++ b/src/Gateway/Handlers/Meta/UnacknowledgedHeartbeatEvent.php
@@ -12,8 +12,8 @@ class UnacknowledgedHeartbeatEvent extends BaseUnacknowledgedHeartbeatEvent
     public function execute(): void
     {
         $this->connection->disconnect(
-            GatewayCloseCodes::LIB_INSTANTIATED_RESUME,
-            'Unacknowledged heartbeat, attempting resume'
+            GatewayCloseCodes::LIB_INSTANTIATED_RECONNECT,
+            'Unacknowledged heartbeat, attempting reconnect'
         );
     }
 }

--- a/tests/Gateway/Handlers/Meta/UnacknowledgedHeartbeatEventTest.php
+++ b/tests/Gateway/Handlers/Meta/UnacknowledgedHeartbeatEventTest.php
@@ -31,7 +31,7 @@ class UnacknowledgedHeartbeatEventTest extends MockeryTestCase
         $connection
             ->shouldReceive()
             ->disconnect()
-            ->with(GatewayCloseCodes::LIB_INSTANTIATED_RESUME, Mockery::type('string'))
+            ->with(GatewayCloseCodes::LIB_INSTANTIATED_RECONNECT, Mockery::type('string'))
             ->once();
 
         $event->execute();


### PR DESCRIPTION
As per docs

> Discord will respond to each Heartbeat event with a [Heartbeat ACK (opcode 11)](https://discord.com/developers/docs/events/gateway#sending-heartbeats) event to confirm it was received. **If an app doesn't receive a Heartbeat ACK, it should close the connection and reconnect.**