### PR TITLE
Fix User Application Role Connection endpoints

### DIFF
--- a/src/Parts/ApplicationRoleConnection.php
+++ b/src/Parts/ApplicationRoleConnection.php
@@ -8,5 +8,5 @@ class ApplicationRoleConnection
 {
     public ?string $platform_name;
     public ?string $platform_username;
-    public ApplicationRoleConnectionMetadata $metadata;
+    public ?object $metadata;
 }

--- a/src/Rest/ApplicationRoleConnectionMetadata.php
+++ b/src/Rest/ApplicationRoleConnectionMetadata.php
@@ -18,11 +18,14 @@ class ApplicationRoleConnectionMetadata extends HttpResource
      *
      * @return PromiseInterface<\Ragnarok\Fenrir\Parts\ApplicationRoleConnectionMetadata>
      */
-    public function getRecords(): PromiseInterface
+    public function getRecords(string $applicationId): PromiseInterface
     {
-        return $this->mapPromise(
+        return $this->mapArrayPromise(
             $this->http->get(
-                Endpoint::APPLICATION_ROLE_CONNECTION_METADATA,
+                Endpoint::bind(
+                    Endpoint::APPLICATION_ROLE_CONNECTION_METADATA,
+                    $applicationId
+                )
             ),
             PartsApplicationRoleConnectionMetadata::class,
         );
@@ -33,11 +36,14 @@ class ApplicationRoleConnectionMetadata extends HttpResource
      *
      * @return PromiseInterface<\Ragnarok\Fenrir\Parts\ApplicationRoleConnectionMetadata>
      */
-    public function updateRecords(array $params): PromiseInterface
+    public function updateRecords(string $applicationId, array $params): PromiseInterface
     {
-        return $this->mapPromise(
+        return $this->mapArrayPromise(
             $this->http->put(
-                Endpoint::APPLICATION_ROLE_CONNECTION_METADATA,
+                Endpoint::bind(
+                    Endpoint::APPLICATION_ROLE_CONNECTION_METADATA,
+                    $applicationId
+                ),
                 $params,
             ),
             PartsApplicationRoleConnectionMetadata::class,

--- a/src/Rest/User.php
+++ b/src/Rest/User.php
@@ -189,11 +189,14 @@ class User extends HttpResource
      *
      * @return PromiseInterface<\Ragnarok\Fenrir\Parts\ApplicationRoleConnection>
      */
-    public function getCurrentUserApplicationRoleConnection(): PromiseInterface
+    public function getCurrentUserApplicationRoleConnection(string $applicationId): PromiseInterface
     {
         return $this->mapPromise(
             $this->http->get(
-                Endpoint::USER_CURRENT_APPLICATION_ROLE_CONNECTION,
+                Endpoint::bind(
+                    Endpoint::USER_CURRENT_APPLICATION_ROLE_CONNECTION,
+                    $applicationId
+                ),
             ),
             ApplicationRoleConnection::class,
         );
@@ -204,11 +207,14 @@ class User extends HttpResource
      *
      * @return PromiseInterface<\Ragnarok\Fenrir\Parts\ApplicationRoleConnection>
      */
-    public function updateCurrentUserApplicationRoleConnection(array $params): PromiseInterface
+    public function updateCurrentUserApplicationRoleConnection(string $applicationId, array $params): PromiseInterface
     {
         return $this->mapPromise(
             $this->http->put(
-                Endpoint::USER_CURRENT_APPLICATION_ROLE_CONNECTION,
+                Endpoint::bind(
+                    Endpoint::USER_CURRENT_APPLICATION_ROLE_CONNECTION,
+                    $applicationId
+                ),
                 $params
             ),
             ApplicationRoleConnection::class,


### PR DESCRIPTION
The user and application role connection needs to have a bind for ":applicationId" so added that, and change mapping to be correct for the data that is returned.